### PR TITLE
Update copyright years in build_ui script, too

### DIFF
--- a/bin/append_license.py
+++ b/bin/append_license.py
@@ -5,7 +5,7 @@ import sys
 
 license_text = [
 "######################################################################################################################\n",
-"# Copyright (C) 2017-2021 Spine project consortium\n",
+"# Copyright (C) 2017-2022 Spine project consortium\n",
 "# This file is part of Spine Toolbox.\n",
 "# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General\n",
 "# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)\n",

--- a/bin/update_copyrights.py
+++ b/bin/update_copyrights.py
@@ -35,3 +35,5 @@ update_copyrights(root_dir, ".py", recursive=False)
 update_copyrights(project_source_dir, ".py")
 update_copyrights(project_source_dir, ".ui")
 update_copyrights(test_source_dir, ".py")
+
+print("Done. Don't forget to update append_license.py!")


### PR DESCRIPTION
Fixes `build_ui.py` script which was accidentally overwriting all updated copyrights in the `ui/` directories.

Re #1820

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
