### PR TITLE
Add zero padding to generated scenario name suffix

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/scenario_generator.py
+++ b/spinetoolbox/spine_db_editor/widgets/scenario_generator.py
@@ -90,7 +90,10 @@ class ScenarioGenerator(QWidget):
             self._insert_base_alternative(scenario_alternatives)
             if operation_label == self._TYPE_LABELS[0]:
                 _ensure_unique(scenario_alternatives)
-        generated_scenario_names = [scenario_prefix + str(count) for count in range(1, len(scenario_alternatives) + 1)]
+        suffix = _suffix(len(scenario_alternatives))
+        generated_scenario_names = [
+            scenario_prefix + suffix.format(count) for count in range(1, len(scenario_alternatives) + 1)
+        ]
         scenario_items = self._db_editor.scenario_items(self._db_map)
         existing_scenario_names = {item.name for item in scenario_items}
         resolution = self._check_existing_scenarios(generated_scenario_names, existing_scenario_names)
@@ -232,3 +235,16 @@ def _find_base_alternative(names):
         return names[0] if names else ""
     else:
         return names[base_index]
+
+
+def _suffix(item_count):
+    """Returns a formattable string with enough zero padding to hold item_count digits.
+
+    Args:
+        item_count (int): maximum number of items
+
+    Returns:
+        str: string in the form '{:0n}' where n is the number of digits in item_count
+    """
+    digit_count = len(str(item_count))
+    return f"{{:0{digit_count}}}"

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -20,11 +20,6 @@ from tests.spine_db_editor.widgets.helpers import add_object, add_object_class, 
 
 
 class TestParameterTableView(TestBase):
-    @classmethod
-    def setUpClass(cls):
-        if not QApplication.instance():
-            QApplication()
-
     def setUp(self):
         self._common_setup("sqlite://", create=True)
 

--- a/tests/spine_db_editor/widgets/test_scenario_generator.py
+++ b/tests/spine_db_editor/widgets/test_scenario_generator.py
@@ -1,0 +1,85 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""Test for `scenario_generator` module."""
+import unittest
+
+from PySide2.QtCore import Qt
+
+from spinetoolbox.helpers import signal_waiter
+from spinetoolbox.spine_db_editor.widgets.scenario_generator import ScenarioGenerator
+from .helpers import TestBase
+
+
+class TestScenarioGenerator(TestBase):
+    def setUp(self):
+        self._common_setup("sqlite://", create=True)
+
+    def tearDown(self):
+        self._common_tear_down()
+
+    def test_alternative_list_contains_alternatives(self):
+        with signal_waiter(self._db_mngr.alternatives_added) as waiter:
+            self._db_mngr.add_alternatives({self._db_map: [{"name": "alt1"}]})
+            waiter.wait()
+        alternatives = self._db_mngr.get_items(self._db_map, "alternative")
+        scenario_generator = ScenarioGenerator(self._db_editor, self._db_map, alternatives, self._db_editor)
+        list_widget = scenario_generator._ui.alternative_list
+        listed_alternatives = [list_widget.item(row).text() for row in range(list_widget.count())]
+        unique_names = set(listed_alternatives)
+        self.assertEqual(len(unique_names), len(listed_alternatives))
+        self.assertEqual({a["name"] for a in alternatives}, unique_names)
+
+    def test_zero_padding_in_generated_scenario_names(self):
+        db_map_items = [{"name": f"alt{n}"} for n in range(13)]
+        with signal_waiter(self._db_mngr.alternatives_added) as waiter:
+            self._db_mngr.add_alternatives({self._db_map: db_map_items})
+            waiter.wait()
+        alternatives = self._db_mngr.get_items(self._db_map, "alternative")
+        scenario_generator = ScenarioGenerator(self._db_editor, self._db_map, alternatives, self._db_editor)
+        scenario_generator._ui.scenario_prefix_edit.setText("S_")
+        scenario_generator._ui.operation_combo_box.setCurrentText("Scenario for each alternative")
+        scenario_generator._ui.use_base_alternative_check_box.setChecked(Qt.Unchecked)
+        scenario_generator._ui.button_box.accepted.emit()
+        scenarios = self._db_mngr.get_items(self._db_map, "scenario")
+        scenario_names = {s["name"] for s in scenarios}
+        self.assertEqual(scenario_names, {f"S_{n:02}" for n in range(1, 15)})
+        scenario_id_to_name = {s["id"]: s["name"] for s in scenarios}
+        alternatives = self._db_mngr.get_items(self._db_map, "alternative")
+        alternative_id_to_name = {a["id"]: a["name"] for a in alternatives}
+        scenario_alternatives = self._db_mngr.get_items(self._db_map, "scenario_alternative")
+        scenario_alternatives_by_name = {
+            scenario_id_to_name[item["scenario_id"]]: (alternative_id_to_name[item["alternative_id"]], item["rank"])
+            for item in scenario_alternatives
+        }
+        self.assertEqual(
+            scenario_alternatives_by_name,
+            {
+                "S_01": ("Base", 1),
+                "S_02": ("alt0", 1),
+                "S_03": ("alt1", 1),
+                "S_04": ("alt2", 1),
+                "S_05": ("alt3", 1),
+                "S_06": ("alt4", 1),
+                "S_07": ("alt5", 1),
+                "S_08": ("alt6", 1),
+                "S_09": ("alt7", 1),
+                "S_10": ("alt8", 1),
+                "S_11": ("alt9", 1),
+                "S_12": ("alt10", 1),
+                "S_13": ("alt11", 1),
+                "S_14": ("alt12", 1),
+            },
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Automatically generated scenario names now have enough zero padding.

Re #1480

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
