### PR TITLE
Filter items that have been removed from fetch chunks

### DIFF
--- a/spinetoolbox/mvcmodels/compound_table_model.py
+++ b/spinetoolbox/mvcmodels/compound_table_model.py
@@ -119,9 +119,15 @@ class CompoundTableModel(MinimalTableModel):
         """Recomputes the row and inverse row maps."""
         self._row_map.clear()
         self._inv_row_map.clear()
+        useful_sub_models = []
         for model in self.sub_models:
+            if model.rowCount() == 0:
+                model.deleteLater()
+                continue
+            useful_sub_models.append(model)
             row_map = self._row_map_for_model(model)
             self._append_row_map(row_map)
+        self.sub_models = useful_sub_models
         self.refreshed.emit()
 
     def _append_row_map(self, row_map):

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_parameter_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_parameter_models.py
@@ -324,8 +324,8 @@ class CompoundParameterModel(FetchParent, CompoundWithEmptyTableModel):
         Args:
             model (SingleParameterModel, EmptyParameterModel)
 
-        Returns:
-            list: tuples (model, row number) for each accepted row
+        Yields:
+            tuple: (model, row number) for each accepted row
         """
         if not self.filter_accepts_model(model):
             return ()
@@ -355,7 +355,8 @@ class CompoundParameterModel(FetchParent, CompoundWithEmptyTableModel):
             ids = {x["id"] for x in data}
             for model in self._models_with_db_map(db_map):
                 if model.entity_class_id in ids:
-                    self.sub_models.remove(model)
+                    i = self.sub_models.index(model)
+                    self.sub_models.pop(i).deleteLater()
         self._do_refresh()
         self.layoutChanged.emit()
 

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -342,9 +342,7 @@ class SpineDBManager(QObject):
                 items = [item for item in (self._pop_item(db_map, item_type, id_) for id_ in ids) if item]
                 if items:
                     db_map_data[db_map] = items
-                    try:
-                        worker = self._get_worker(db_map)
-                    except KeyError:
+                    if db_map not in self._workers:
                         continue
             if db_map_data:
                 typed_db_map_data[item_type] = db_map_data


### PR DESCRIPTION
Spine DB workers now drop ids that don't exist anymore when fetching.

Fixes #1834

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
