### PR TITLE
Disconnect change notifiers from undo stack signals when parent widgets get closed

### DIFF
--- a/spinetoolbox/project_item/specification_editor_window.py
+++ b/spinetoolbox/project_item/specification_editor_window.py
@@ -215,6 +215,7 @@ class SpecificationEditorWindowBase(QMainWindow):
             self.focusWidget().clearFocus()
         if not self._undo_stack.isClean() and not prompt_to_save_changes(self, self._toolbox.qsettings(), self._save):
             return False
+        self._change_notifier.tear_down()
         self._undo_stack.cleanChanged.disconnect(self._update_window_modified)
         save_ui(self, self._app_settings, self.settings_group)
         return True

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -164,8 +164,7 @@ class SpineDBEditorBase(QMainWindow):
             self.save_window_state()
         self.db_maps = []
         self._changelog.clear()
-        while self._change_notifiers:
-            self._change_notifiers.pop(0).deleteLater()
+        self._purge_change_notifiers()
         for url, codename in db_url_codenames.items():
             db_map = self.db_mngr.get_db_map(url, self, codename=codename, create=create)
             if db_map is not None:
@@ -971,6 +970,7 @@ class SpineDBEditorBase(QMainWindow):
                 commit_msg = self._get_commit_msg(db_names)
                 if not commit_msg:
                     return False
+        self._purge_change_notifiers()
         self._torn_down = True
         self.db_mngr.unregister_listener(self, *self.db_maps, commit_dirty=commit_dirty, commit_msg=commit_msg)
         return True
@@ -1041,6 +1041,13 @@ class SpineDBEditorBase(QMainWindow):
         message_box.button(QMessageBox.Ok).setText("Rollback")
         answer = message_box.exec_()
         return answer == QMessageBox.Ok
+
+    def _purge_change_notifiers(self):
+        """Tears down change notifiers."""
+        while self._change_notifiers:
+            notifier = self._change_notifiers.pop(0)
+            notifier.tear_down()
+            notifier.deleteLater()
 
     def closeEvent(self, event):
         """Handle close window.

--- a/spinetoolbox/widgets/notification.py
+++ b/spinetoolbox/widgets/notification.py
@@ -25,7 +25,11 @@ from spinetoolbox.helpers import color_from_index
 class Notification(QFrame):
     """Custom pop-up notification widget with fade-in and fade-out effect."""
 
-    def __init__(self, parent, txt, anim_duration=500, life_span=None, word_wrap=True, corner=Qt.TopRightCorner):
+    _FADE_IN_OUT_DURATION = 500
+
+    def __init__(
+        self, parent, txt, anim_duration=_FADE_IN_OUT_DURATION, life_span=None, word_wrap=True, corner=Qt.TopRightCorner
+    ):
         """
 
         Args:
@@ -194,6 +198,8 @@ class LinkNotification(Notification):
 
 
 class ChangeNotifier(QObject):
+    _ANIMATION_LIFE_SPAN = 5000
+
     def __init__(self, parent, undo_stack, settings, settings_key, corner=Qt.BottomRightCorner):
         """
         Args:
@@ -201,6 +207,7 @@ class ChangeNotifier(QObject):
             undo_stack (QUndoStack)
             settings (QSettings)
             settings_key (str)
+            corner (int)
         """
         super().__init__(undo_stack)
         self._undo_stack = undo_stack
@@ -238,10 +245,14 @@ class ChangeNotifier(QObject):
         self._notification = ButtonNotification(
             self._parent,
             notification_text,
-            life_span=5000,
+            life_span=self._ANIMATION_LIFE_SPAN,
             word_wrap=False,
             corner=self._corner,
             button_text=button_text,
             button_slot=button_slot,
         )
         self._notification.show()
+
+    def tear_down(self):
+        """Tears down the notifier."""
+        self._undo_stack.indexChanged.disconnect(self._push_notification)

--- a/tests/widgets/test_notification.py
+++ b/tests/widgets/test_notification.py
@@ -1,0 +1,58 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""Contains unit tests for the ``notification`` module."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from PySide2.QtCore import QAbstractAnimation
+from PySide2.QtWidgets import QApplication, QUndoCommand, QUndoStack, QWidget
+from spinetoolbox.widgets.notification import Notification, ChangeNotifier
+
+
+class TestChangeNotifier(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._parent = QWidget()
+        self._undo_stack = QUndoStack(self._parent)
+
+    def tearDown(self):
+        self._parent.deleteLater()
+
+    @patch.object(Notification, "_FADE_IN_OUT_DURATION", new=1)
+    @patch.object(ChangeNotifier, "_ANIMATION_LIFE_SPAN", new=1)
+    def test_tear_down_disconnects_signals(self):
+        app_settings = MagicMock()
+        app_settings.value.return_value = "2"
+        notifier = ChangeNotifier(self._parent, self._undo_stack, app_settings, "settings key")
+        with patch.object(Notification, "show") as show_method:
+            self._undo_stack.push(QUndoCommand("something"))
+            while notifier._notification.fade_in_anim.state() != QAbstractAnimation.Stopped:
+                QApplication.processEvents()
+            notifier._notification.start_self_destruction()
+            try:
+                while notifier._notification.fade_out_anim.state() != QAbstractAnimation.Stopped:
+                    QApplication.processEvents()
+            except RuntimeError:
+                pass
+            show_method.assert_called_once()
+        notifier.tear_down()
+        with patch.object(Notification, "show") as show_method:
+            self._undo_stack.push(QUndoCommand("something else"))
+            show_method.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Before this PR, it was possible to e.g. close the Database editor before it had time to show all notification widgets causing a Traceback due to change notifier being deleted on C++ side.

Fixes #1831

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
