### PR TITLE
Use attribute and item lookups from 'operator' where applicable

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1395,6 +1395,16 @@ def save_ui(window, app_settings, settings_group):
 
 
 def bisect_chunks(current_data, new_data, key=None):
+    """Finds insertion points for chunks of data using binary search.
+
+    Args:
+        current_data (list): sorted list where to insert new data
+        new_data (list): data to insert
+        key (Callable, optional): sort key
+
+    Returns:
+        tuple: sorted chunk of new data, insertion position
+    """
     if key is not None:
         current_data = [key(x) for x in current_data]
     else:

--- a/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model_base.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model_base.py
@@ -16,6 +16,8 @@ Contains base class for metadata table models associated functionality.
 :date:   25.4.2022
 """
 from enum import IntEnum, unique
+from operator import itemgetter
+
 from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal
 from spinetoolbox.helpers import rows_to_row_count_tuples
 from .colors import FIXED_FIELD_COLOR
@@ -447,14 +449,11 @@ class MetadataTableModelBase(QAbstractTableModel):
         if not self._data or column < 0:
             return
 
-        def string_sort_key(row):
-            return row[column]
-
         def db_map_sort_key(row):
             db_map = row[Column.DB_MAP]
             return db_map.codename if db_map is not None else ""
 
-        sort_key = string_sort_key if column != Column.DB_MAP else db_map_sort_key
+        sort_key = itemgetter(column) if column != Column.DB_MAP else db_map_sort_key
         self._data.sort(key=sort_key, reverse=order == Qt.DescendingOrder)
         top_left = self.index(0, 0)
         bottom_right = self.index(len(self._data) - 1, Column.DB_MAP)

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -227,7 +227,7 @@ class MultiDBTreeItem(FetchParent, TreeItem):
 
     @property
     def _children_sort_key(self):
-        return lambda item: item.display_id
+        return attrgetter("display_id")
 
     def fetch_status_change(self):
         """Notifies the view that the model's layout has changed.

--- a/spinetoolbox/widgets/custom_qtableview.py
+++ b/spinetoolbox/widgets/custom_qtableview.py
@@ -23,6 +23,8 @@ import locale
 from contextlib import contextmanager
 from numbers import Number
 import re
+from operator import methodcaller
+
 from PySide2.QtWidgets import QTableView, QApplication, QAction
 from PySide2.QtCore import Qt, Slot, QItemSelection, QItemSelectionModel, QPoint
 from PySide2.QtGui import QKeySequence, QIcon
@@ -611,7 +613,7 @@ class ArrayTableView(IndexedParameterValueTableViewBase):
             return False
         model = self.model()
         selected_indexes = [i for i in selection_model.selectedIndexes() if not model.is_expanse_row(i.row())]
-        selected_indexes.sort(key=lambda index: index.row())
+        selected_indexes.sort(key=methodcaller("row"))
         values = [index.data() for index in selected_indexes]
         with system_lc_numeric():
             with io.StringIO() as output:

--- a/tests/spine_db_editor/mvcmodels/test_tree_item_utility.py
+++ b/tests/spine_db_editor/mvcmodels/test_tree_item_utility.py
@@ -1,0 +1,57 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for the ``tree_item_utility`` module."""
+from operator import attrgetter
+import unittest
+
+from spinetoolbox.spine_db_editor.mvcmodels.tree_item_utility import SortChildrenMixin
+
+
+class TestSortsChildrenMixin(unittest.TestCase):
+    class ChildrenSorterBase:
+        def __init__(self):
+            self.non_empty_children = []
+
+        def insert_children(self, position, children):
+            self.non_empty_children = self.non_empty_children[:position] + children + self.non_empty_children[position:]
+            return True
+
+        def child_ns(self):
+            return list(map(attrgetter("n"), self.non_empty_children))
+
+    class ChildrenSorter(SortChildrenMixin, ChildrenSorterBase):
+        pass
+
+    class Child:
+        def __init__(self, n):
+            self.n = n
+
+        def data(self, i):
+            if i != 0:
+                raise RuntimeError(f"i must be 0, got {i}")
+            return self.n
+
+    def test_insert_children_sorted_to_empty_data(self):
+        sorter = self.ChildrenSorter()
+        new_children = list(map(self.Child, [4, 2, 6]))
+        self.assertTrue(sorter.insert_children_sorted(new_children))
+        self.assertEqual(sorter.child_ns(), [2, 4, 6])
+
+    def test_insert_children_sorted_to_existing_list(self):
+        sorter = self.ChildrenSorter()
+        sorter.non_empty_children = list(map(self.Child, [3, 7, 9]))
+        new_children = list(map(self.Child, [4, 2, 6]))
+        self.assertTrue(sorter.insert_children_sorted(new_children))
+        self.assertEqual(sorter.child_ns(), [2, 3, 4, 6, 7, 9])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
No functional changes intended. Replaced lambdas used as sort keys by tools from `operator` which are slightly more performant.

Fixes #1854

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
