### PR TITLE
Place plot legend on bottom or right of data axes depending on legend size

### DIFF
--- a/spinetoolbox/plotting.py
+++ b/spinetoolbox/plotting.py
@@ -55,19 +55,6 @@ _TIME_SERIES_PLOT_SETTINGS = {"where": "post"}
 class PlottingError(Exception):
     """An exception signalling failure in plotting."""
 
-    def __init__(self, message):
-        """
-        Args:
-            message (str): an error message
-        """
-        super().__init__()
-        self._message = message
-
-    @property
-    def message(self):
-        """str: the error message."""
-        return self._message
-
 
 @dataclass(frozen=True)
 class XYData:

--- a/spinetoolbox/plotting.py
+++ b/spinetoolbox/plotting.py
@@ -39,7 +39,11 @@ from spinedb_api import (
 )
 from .helpers import first_non_null
 from .mvcmodels.shared import PARSED_ROLE
+from .widgets.plot_canvas import LegendPosition
 from .widgets.plot_widget import PlotWidget
+
+
+LEGEND_PLACEMENT_THRESHOLD = 8
 
 
 _BASE_SETTINGS = {"alpha": 0.7}
@@ -248,7 +252,11 @@ def plot_data(data_list, plot_widget=None):
         a PlotWidget object
     """
     if plot_widget is None:
-        plot_widget = PlotWidget()
+        plot_widget = PlotWidget(
+            legend_axes_position=LegendPosition.BOTTOM
+            if len(data_list) < LEGEND_PLACEMENT_THRESHOLD
+            else LegendPosition.RIGHT
+        )
         needs_redraw = False
     else:
         needs_redraw = True

--- a/spinetoolbox/widgets/plot_canvas.py
+++ b/spinetoolbox/widgets/plot_canvas.py
@@ -15,26 +15,40 @@ A Qt widget to use as a matplotlib backend.
 :author: A. Soininen (VTT)
 :date:   3.6.2019
 """
-
+from enum import auto, Enum, unique
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 from PySide2 import QtWidgets
 
 
+@unique
+class LegendPosition(Enum):
+    BOTTOM = auto()
+    RIGHT = auto()
+
+
 class PlotCanvas(FigureCanvasQTAgg):
     """A widget for plotting with matplotlib."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, legend_axes_position=LegendPosition.BOTTOM):
         """
         Args:
-            parent (QWidget): a parent widget
+            legend_axes_position (LegendPosition): legend axes position relative to plot axes
+            parent (QWidget, optional): a parent widget
         """
-        width = 7.0  # inches
-        height = 4.0  # inches
+        width = 7.0 + (0.0 if legend_axes_position == LegendPosition.BOTTOM else 6.0)  # inches
+        height = 5.0  # inches
         fig = Figure(figsize=(width, height), tight_layout=True)
-        grid_spec = fig.add_gridspec(2, 1, height_ratios=[1, 0])
-        self._axes = fig.add_subplot(grid_spec[0, 0])
-        self._legend_axes = fig.add_subplot(grid_spec[1, 0])
+        if legend_axes_position == LegendPosition.BOTTOM:
+            grid_spec = fig.add_gridspec(2, 1, height_ratios=[1, 0])
+            self._axes = fig.add_subplot(grid_spec[0, 0])
+            self._legend_axes = fig.add_subplot(grid_spec[1, 0])
+        elif legend_axes_position == LegendPosition.RIGHT:
+            grid_spec = fig.add_gridspec(1, 2, width_ratios=[1, 0])
+            self._axes = fig.add_subplot(grid_spec[0, 0])
+            self._legend_axes = fig.add_subplot(grid_spec[0, 1])
+        else:
+            raise RuntimeError(f"unknown legend position {legend_axes_position}")
         self._legend_axes.axis("off")
         super().__init__(fig)
         self.setParent(parent)

--- a/spinetoolbox/widgets/plot_widget.py
+++ b/spinetoolbox/widgets/plot_widget.py
@@ -19,15 +19,12 @@ A Qt widget showing a toolbar and a matplotlib plotting canvas.
 import itertools
 import io
 import csv
-from datetime import datetime
 
 import numpy
-import numpy as np
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolBar
 from PySide2.QtCore import QMetaObject, Qt
 from PySide2.QtWidgets import QVBoxLayout, QWidget, QMenu, QApplication
-from spinedb_api import IndexedValue, Map, TimeSeries
-from .plot_canvas import PlotCanvas
+from .plot_canvas import PlotCanvas, LegendPosition
 from .custom_qtableview import CopyPasteTableView
 from ..mvcmodels.minimal_table_model import MinimalTableModel
 from ..helpers import busy_effect
@@ -45,14 +42,15 @@ class PlotWidget(QWidget):
     plot_windows = dict()
     """A global list of plot windows."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, legend_axes_position=LegendPosition.BOTTOM):
         """
         Args:
-            parent (QWidget): parent widget
+            parent (QWidget, optional): parent widget
+            legend_axes_position (LegendPosition): legend axes position relative to plot axes
         """
         super().__init__(parent)
         self._layout = QVBoxLayout(self)
-        self.canvas = PlotCanvas(self)
+        self.canvas = PlotCanvas(self, legend_axes_position)
         self._toolbar = NavigationToolBar(self.canvas, self)
         self._layout.addWidget(self._toolbar)
         self._layout.addWidget(self.canvas)

--- a/spinetoolbox/widgets/report_plotting_failure.py
+++ b/spinetoolbox/widgets/report_plotting_failure.py
@@ -20,5 +20,10 @@ from PySide2.QtWidgets import QMessageBox
 
 
 def report_plotting_failure(error, parent_widget):
-    """Reports a PlottingError exception to the user."""
-    QMessageBox.warning(parent_widget, "Plotting Failed", error.message)
+    """Reports a PlottingError exception to the user.
+
+    Args:
+        error (PlottingError): exception to report
+        parent_widget (QWidget): parent widget
+    """
+    QMessageBox.warning(parent_widget, "Plotting Failed", str(error))

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -48,6 +48,7 @@ from spinetoolbox.plotting import (
     raise_if_incompatible_x,
     plot_pivot_table_selection,
     LEGEND_PLACEMENT_THRESHOLD,
+    add_row_to_exception,
 )
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
 
@@ -808,6 +809,20 @@ class TestRaiseIfIncompatibleX(unittest.TestCase):
             ),
         ]
         self.assertRaises(PlottingError, raise_if_incompatible_x, data_list)
+
+
+class TestAddRowToException(unittest.TestCase):
+    def test_exception_message_formatted_correctly(self):
+        row = 23
+
+        def display_row(r):
+            self.assertEqual(r, row)
+            return 99
+
+        with self.assertRaises(PlottingError) as context_manager:
+            with add_row_to_exception(row, display_row):
+                raise PlottingError("detailed error message")
+        self.assertEqual(str(context_manager.exception), "Failed to plot row 99: detailed error message")
 
 
 class MultiSignalWaiter(QObject):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -23,6 +23,7 @@ from unittest.mock import Mock, MagicMock, patch
 import numpy
 from PySide2.QtCore import QModelIndex, QItemSelectionModel, QObject
 from PySide2.QtWidgets import QApplication, QMessageBox
+from matplotlib.gridspec import GridSpec
 
 from spinedb_api import (
     DateTime,
@@ -46,6 +47,7 @@ from spinetoolbox.plotting import (
     plot_data,
     raise_if_incompatible_x,
     plot_pivot_table_selection,
+    LEGEND_PLACEMENT_THRESHOLD,
 )
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
 
@@ -749,8 +751,8 @@ class TestPlotData(unittest.TestCase):
 
     def test_we_find_unsqueezed_index_no_matter_what(self):
         data = [
-            XYData(x=['t1', 't2'], y=[13.0, 7.0], x_label='x', y_label='', data_index=['A1'], index_names=['x']),
-            XYData(x=['B1', 'B2'], y=[-13.0, -7.0], x_label='x', y_label='', data_index=[], index_names=[]),
+            XYData(x=["t1", "t2"], y=[13.0, 7.0], x_label="x", y_label="", data_index=["A1"], index_names=["x"]),
+            XYData(x=["B1", "B2"], y=[-13.0, -7.0], x_label="x", y_label="", data_index=[], index_names=[]),
         ]
         plot_widget = plot_data(data)
         self.assertEqual(plot_widget.canvas.axes.get_title(), "")
@@ -765,6 +767,24 @@ class TestPlotData(unittest.TestCase):
         self.assertEqual(list(lines[0].get_ydata(orig=True)), [13.0, 7.0])
         self.assertEqual(list(lines[1].get_xdata(orig=True)), ["B1", "B2"])
         self.assertEqual(list(lines[1].get_ydata(orig=True)), [-13.0, -7.0])
+
+    def test_legend_placement_below_threshold(self):
+        data = [
+            XYData(x=["x"], y=[1.0], x_label="x", y_label="", data_index=[], index_names=[])
+            for _ in range(LEGEND_PLACEMENT_THRESHOLD - 1)
+        ]
+        plot_widget = plot_data(data)
+        self.assertEqual(
+            repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(2, 1, height_ratios=[1, 0]))
+        )
+
+    def test_legend_placement_above_threshold(self):
+        data = [
+            XYData(x=["x"], y=[1.0], x_label="x", y_label="", data_index=[], index_names=[])
+            for _ in range(LEGEND_PLACEMENT_THRESHOLD)
+        ]
+        plot_widget = plot_data(data)
+        self.assertEqual(repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(1, 2, width_ratios=[1, 0])))
 
 
 class TestRaiseIfIncompatibleX(unittest.TestCase):

--- a/tests/widgets/test_plot_widget.py
+++ b/tests/widgets/test_plot_widget.py
@@ -15,10 +15,12 @@ import unittest
 from itertools import product
 from unittest import mock
 
+from matplotlib.gridspec import GridSpec
 from PySide2.QtWidgets import QApplication
 
 from spinedb_api.parameter_value import TimeSeriesFixedResolution
 from spinetoolbox.plotting import plot_data, TreeNode, turn_node_to_xy_data, convert_indexed_value_to_tree
+from spinetoolbox.widgets.plot_canvas import LegendPosition
 from spinetoolbox.widgets.plot_widget import PlotWidget, _PlotDataWidget
 
 
@@ -63,6 +65,16 @@ class TestPlotWidget(unittest.TestCase):
         ]
         for row, column in product(range(model.rowCount()), range(model.columnCount())):
             self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_legend_axes_placement_bottom(self):
+        plot_widget = PlotWidget(legend_axes_position=LegendPosition.BOTTOM)
+        self.assertEqual(
+            repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(2, 1, height_ratios=[1, 0]))
+        )
+
+    def test_legend_axes_placement_right(self):
+        plot_widget = PlotWidget(legend_axes_position=LegendPosition.RIGHT)
+        self.assertEqual(repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(1, 2, width_ratios=[1, 0])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR makes plot windows wider and places the legend right of the plot axes if the legend contains more entries than a hard-coded threshold.

Fixes #1857

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
