### PR TITLE
More async fetching

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1433,6 +1433,9 @@ class FetchParent:
     _busy = False
     iterator = None
     will_have_children = None
+    """Whether this parent will have children if fetched.
+    None means we don't know yet. Set to a boolean value whenever we find out.
+    """
 
     @property
     def fetch_item_type(self):
@@ -1446,12 +1449,11 @@ class FetchParent:
 
     # pylint: disable=no-self-use
     def accepts_item(self, item, db_map):
-        """Called by the associated SpineDBWorker whenever items are added/updated/removed.
-        Returns whether this parent should react to that modification.
-        It should be consistent with ``filter_query()`` of course.
+        """Called by the associated SpineDBWorker whenever items are fetched and also added/updated/removed.
+        Returns whether this parent should accept that item as a children.
 
-        The SpineDBWorker will call one or more of ``handle_items_added()``, ``handle_items_updated()``,
-        or ``handle_items_removed()`` with all the items that pass this test.
+        In case of modifications, the SpineDBWorker will call one or more of ``handle_items_added()``,
+        ``handle_items_updated()``, or ``handle_items_removed()`` with all the items that pass this test.
 
         Args:
             item (dict): The item
@@ -1559,11 +1561,9 @@ class FlexibleFetchParent(ItemTypeFetchParent):
         handle_items_added=None,
         handle_items_removed=None,
         handle_items_updated=None,
-        filter_query=None,
         accepts_item=None,
     ):
         super().__init__(fetch_item_type)
-        self._filter_query = filter_query
         self._accepts_item = accepts_item
         self._handle_items_added = handle_items_added
         self._handle_items_removed = handle_items_removed
@@ -1583,11 +1583,6 @@ class FlexibleFetchParent(ItemTypeFetchParent):
         if self._handle_items_updated is None:
             return
         self._handle_items_updated(db_map_data)
-
-    def filter_query(self, query, subquery, db_map):
-        if self._filter_query is None:
-            return super().filter_query(query, subquery, db_map)
-        return self._filter_query(query, subquery, db_map)
 
     def accepts_item(self, item, db_map):
         if self._accepts_item is None:

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_parameter_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_parameter_models.py
@@ -72,11 +72,6 @@ class CompoundParameterModel(FetchParent, CompoundWithEmptyTableModel):
         for db_map in self.db_maps:
             self.db_mngr.fetch_more(db_map, self)
 
-    def filter_query(self, query, subquery, db_map):
-        return query.filter(getattr(subquery.c, self.entity_class_id_key).isnot(None)).order_by(
-            subquery.c.entity_class_name
-        )
-
     def accepts_item(self, item, db_map):
         return item[self.entity_class_id_key] is not None
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -94,9 +94,6 @@ class EntityClassItem(MultiDBTreeItem):
                 return QBrush(Qt.gray)
         return super().data(column, role)
 
-    def filter_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.class_id == self.db_map_id(db_map))
-
     def accepts_item(self, item, db_map):
         return item["class_id"] == self.db_map_id(db_map)
 
@@ -146,12 +143,6 @@ class ObjectRelationshipClassItem(RelationshipClassItem):
         """See base class."""
         return False
 
-    def filter_query(self, query, subquery, db_map):
-        object_id = self.parent_item.db_map_id(db_map)
-        ids = set(x.id for x in db_map.query(db_map.relationship_sq).filter_by(object_id=object_id))
-        query = query.filter(db_map.in_(subquery.c.id, ids))
-        return super().filter_query(query, subquery, db_map)
-
     def accepts_item(self, item, db_map):
         if not super().accepts_item(item, db_map):
             return False
@@ -183,10 +174,6 @@ class MemberObjectClassItem(ObjectClassItem):
         return self.db_mngr.entity_class_icon(
             self.first_db_map, super().item_type, self.db_map_id(self.first_db_map), for_group=False
         )
-
-    def filter_query(self, query, subquery, db_map):
-        query = query.filter(subquery.c.group_id == self.parent_item.db_map_id(db_map))
-        return super().filter_query(query, subquery, db_map)
 
     def accepts_item(self, item, db_map):
         return super().accepts_item(item, db_map) and item["group_id"] == self.parent_item.db_map_id(db_map)
@@ -267,11 +254,6 @@ class ObjectItem(EntityItem):
             object_name=self.display_data,
             database=self.first_db_map.codename,
         )
-
-    def filter_query(self, query, subquery, db_map):
-        object_class_id = self.db_map_data_field(db_map, 'class_id')
-        ids = set(x.id for x in db_map.query(db_map.relationship_class_sq).filter_by(object_class_id=object_class_id))
-        return query.filter(db_map.in_(subquery.c.id, ids))
 
     def accepts_item(self, item, db_map):
         if not super().accepts_item(item, db_map):

--- a/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
@@ -60,7 +60,6 @@ class ItemMetadataTableModel(MetadataTableModelBase):
             handle_items_added=self.add_item_metadata,
             handle_items_removed=self.remove_item_metadata,
             handle_items_updated=self.update_item_metadata,
-            filter_query=self._filter_entity_metadata_query,
             accepts_item=self._accepts_entity_metadata_item,
         )
         self._parameter_value_metadata_fetch_parent = FlexibleFetchParent(
@@ -68,7 +67,6 @@ class ItemMetadataTableModel(MetadataTableModelBase):
             handle_items_added=self.add_item_metadata,
             handle_items_removed=self.remove_item_metadata,
             handle_items_updated=self.update_item_metadata,
-            filter_query=self._filter_parameter_value_metadata_query,
             accepts_item=self._accepts_parameter_value_metadata_item,
         )
 
@@ -89,20 +87,10 @@ class ItemMetadataTableModel(MetadataTableModelBase):
         """See base class."""
         return [None, None]
 
-    def _filter_entity_metadata_query(self, query, subquery, db_map):
-        if self._item_type != ItemType.ENTITY:
-            return query.filter(False)
-        return query.filter_by(entity_id=self._item_ids.get(db_map))
-
     def _accepts_entity_metadata_item(self, item, db_map):
         if self._item_type != ItemType.ENTITY:
             return False
         return item["entity_id"] == self._item_ids.get(db_map)
-
-    def _filter_parameter_value_metadata_query(self, query, subquery, db_map):
-        if self._item_type != ItemType.VALUE:
-            return query.filter(False)
-        return query.filter_by(parameter_value_id=self._item_ids.get(db_map))
 
     def _accepts_parameter_value_metadata_item(self, item, db_map):
         if self._item_type != ItemType.VALUE:

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -229,9 +229,9 @@ class MultiDBTreeItem(FetchParent, TreeItem):
     def _children_sort_key(self):
         return attrgetter("display_id")
 
-    def fetch_status_change(self):
+    def will_have_children_change(self):
         """Notifies the view that the model's layout has changed.
-        This triggers a repaint so this item may be painted gray if no children."""
+        This triggers a repaint so this item will be painted gray if no children."""
         self.model.layoutChanged.emit()
 
     @property

--- a/spinetoolbox/spine_db_editor/mvcmodels/parameter_value_list_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/parameter_value_list_item.py
@@ -82,9 +82,6 @@ class ListItem(
     def _make_child(self, id_):
         return ValueItem(id_)
 
-    def filter_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.parameter_value_list_id == self.id)
-
     def accepts_item(self, item, db_map):
         return item["parameter_value_list_id"] == self.id
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -732,7 +732,6 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             handle_items_added=self._handle_entities_added,
             handle_items_removed=self._handle_entities_removed,
             handle_items_updated=lambda _: self._parent.refresh_views(),
-            filter_query=self._filter_entity_query,
             accepts_item=self._accepts_entity_item,
         )
         self._relationship_fetch_parent = FlexibleFetchParent(
@@ -740,7 +739,6 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             handle_items_added=self._handle_entities_added,
             handle_items_removed=self._handle_entities_removed,
             handle_items_updated=lambda _: self._parent.refresh_views(),
-            filter_query=self._filter_entity_query,
             accepts_item=self._accepts_entity_item,
         )
         self._parameter_definition_fetch_parent = FlexibleFetchParent(
@@ -748,7 +746,6 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             handle_items_added=self._handle_parameter_definitions_added,
             handle_items_removed=self._handle_parameter_definitions_removed,
             handle_items_updated=lambda _: self._parent.refresh_views(),
-            filter_query=self._filter_parameter_query,
             accepts_item=self._accepts_parameter_item,
         )
         self._parameter_value_fetch_parent = FlexibleFetchParent(
@@ -756,7 +753,6 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             handle_items_added=self._handle_parameter_values_added,
             handle_items_removed=self._handle_parameter_values_removed,
             handle_items_updated=lambda _: self._parent.refresh_views(),
-            filter_query=self._filter_parameter_query,
             accepts_item=self._accepts_parameter_item,
         )
         self._alternative_fetch_parent = FlexibleFetchParent(
@@ -766,14 +762,8 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             handle_items_updated=lambda _: self._parent.refresh_views(),
         )
 
-    def _filter_entity_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.class_id == self._parent.current_class_id.get(db_map))
-
     def _accepts_entity_item(self, item, db_map):
         return item["class_id"] == self._parent.current_class_id.get(db_map)
-
-    def _filter_parameter_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.entity_class_id == self._parent.current_class_id.get(db_map))
 
     def _accepts_parameter_item(self, item, db_map):
         return item["entity_class_id"] == self._parent.current_class_id.get(db_map)
@@ -1155,7 +1145,6 @@ class RelationshipPivotTableModel(PivotTableModelBase):
             handle_items_added=self._handle_relationships_added,
             handle_items_removed=self._handle_relationships_removed,
             handle_items_updated=lambda _: self._parent.refresh_views(),
-            filter_query=self._filter_relationship_query,
             accepts_item=self._accepts_relationship_item,
         )
         self._object_fetch_parent = FlexibleFetchParent(
@@ -1163,19 +1152,11 @@ class RelationshipPivotTableModel(PivotTableModelBase):
             handle_items_added=self._handle_objects_added,
             handle_items_removed=self._handle_objects_removed,
             handle_items_updated=lambda _: self._parent.refresh_views(),
-            filter_query=self._filter_object_query,
             accepts_item=self._accepts_object_item,
         )
 
-    def _filter_relationship_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.class_id == self._parent.current_class_id.get(db_map))
-
     def _accepts_relationship_item(self, item, db_map):
         return item["class_id"] == self._parent.current_class_id.get(db_map)
-
-    def _filter_object_query(self, query, subquery, db_map):
-        object_class_id_list = {x[db_map] for x in self._parent.current_object_class_id_list}
-        return query.filter(db_map.in_(subquery.c.class_id, object_class_id_list))
 
     def _accepts_object_item(self, item, db_map):
         object_class_id_list = {x[db_map] for x in self._parent.current_object_class_id_list}

--- a/spinetoolbox/spine_db_editor/mvcmodels/tool_feature_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tool_feature_item.py
@@ -190,9 +190,6 @@ class ToolFeatureRootItem(EmptyChildRootItem):
     def _make_child(self, id_):
         return ToolFeatureLeafItem(id_)
 
-    def filter_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.tool_id == self.parent_item.id)
-
     def accepts_item(self, item, db_map):
         return item["tool_id"] == self.parent_item.id
 
@@ -284,7 +281,7 @@ class ToolFeatureMethodRootItem(EmptyChildRootItem):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._list_value_fetch_parent = FlexibleFetchParent("list_value", filter_query=self._filter_list_value_query)
+        self._list_value_fetch_parent = FlexibleFetchParent("list_value", accepts_item=self._accepts_list_value_item)
 
     def _fetch_parents(self):
         yield self._list_value_fetch_parent
@@ -308,14 +305,11 @@ class ToolFeatureMethodRootItem(EmptyChildRootItem):
     def _make_child(self, id_):
         return ToolFeatureMethodLeafItem(id_)
 
-    def filter_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.tool_feature_id == self.parent_item.id)
-
     def accepts_item(self, item, db_map):
         return item["tool_feature_id"] == self.parent_item.id
 
-    def _filter_list_value_query(self, query, subquery, db_map):
-        return query.filter(subquery.c.parameter_value_list_id == self.parent_item.item_data["parameter_value_list_id"])
+    def _accepts_list_value_item(self, item, db_map):
+        return item["parameter_value_list_id"] == self.parent_item.item_data["parameter_value_list_id"]
 
 
 class ToolFeatureMethodLeafItem(GrayIfLastMixin, LeafItem):

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
@@ -148,7 +148,6 @@ class FetchMoreMixin:
             handle_items_added=self.handle_items_added,
             handle_items_removed=self.handle_items_removed,
             handle_items_updated=self.handle_items_updated,
-            filter_query=self.filter_query,
             accepts_item=self.accepts_item,
         )
 
@@ -171,10 +170,6 @@ class FetchMoreMixin:
 
     def _make_child(self, id_):
         raise NotImplementedError()
-
-    # pylint: disable=no-self-use
-    def filter_query(self, query, subquery, db_map):
-        return query
 
     def accepts_item(self, item, db_map):
         return True

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -80,7 +80,6 @@ class GraphViewMixin:
             handle_items_added=self._handle_objects_added,
             handle_items_removed=self._handle_objects_removed,
             handle_items_updated=self._handle_objects_updated,
-            filter_query=self._filter_query,
             accepts_item=self._accepts_item,
         )
         self._relationship_fetch_parent = FlexibleFetchParent(
@@ -88,7 +87,6 @@ class GraphViewMixin:
             handle_items_added=self._handle_relationships_added,
             handle_items_removed=self._handle_relationships_removed,
             handle_items_updated=self._handle_relationships_updated,
-            filter_query=self._filter_query,
             accepts_item=self._accepts_item,
         )
 
@@ -130,10 +128,6 @@ class GraphViewMixin:
                 id_ = item.db_map_ids.get(db_map)
                 if id_:
                     yield id_
-
-    def _filter_query(self, query, sq, db_map):
-        class_ids = set(self._selected_class_ids(db_map))
-        return query.filter(db_map.in_(sq.c.class_id, class_ids))
 
     def _accepts_item(self, item, db_map):
         class_ids = set(self._selected_class_ids(db_map))

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -20,14 +20,14 @@ import itertools
 from enum import Enum, unique, auto
 from PySide2.QtCore import QObject, Signal, Slot
 from spinedb_api import DiffDatabaseMapping, SpineDBAPIError
-from .helpers import busy_effect, separate_metadata_and_item_metadata, FetchParent
+from .helpers import busy_effect, separate_metadata_and_item_metadata
 from .qthread_pool_executor import QtBasedThreadPoolExecutor
 
 
 @unique
 class _Event(Enum):
-    FETCH = auto()
-    FETCH_STATUS_CHANGE = auto()
+    MORE_AVAILABLE = auto()
+    WILL_HAVE_CHILDREN_CHANGE = auto()
     ADD_ITEMS = auto()
     UPDATE_ITEMS = auto()
     REMOVE_ITEMS = auto()
@@ -60,6 +60,48 @@ def _db_map_lock(func):
     return new_function
 
 
+def _by_chunks(it):
+    """
+    Iterate given iterator by chunks.
+
+    Args:
+        it (Iterable)
+    Yields:
+        list: chunk of items
+    """
+    while True:
+        chunk = list(itertools.islice(it, _CHUNK_SIZE))
+        yield chunk
+        if not chunk:
+            break
+
+
+class _CacheIterator:
+    def __init__(self, worker, parent):
+        self._worker = worker
+        self._parent = parent
+        self._iter_position = 0
+
+    def _set_iter_position(self, position):
+        self._iter_position = position
+
+    def _next_chunk(self):
+        k = 0
+        for item in self._worker.iterate_cache(self._parent, self._iter_position, self._set_iter_position):
+            yield item
+            k += 1
+            if k == _CHUNK_SIZE:
+                return
+        if not self._parent.is_fetched and k == 0:
+            self._worker.advance_query_iterator(self._parent)
+
+    def __next__(self):
+        return list(self._next_chunk())
+
+    def __iter__(self):
+        return self
+
+
 class SpineDBWorker(QObject):
     """Does all the communication with a certain DB for SpineDBManager, in a non-GUI thread."""
 
@@ -71,9 +113,10 @@ class SpineDBWorker(QObject):
         self._db_mngr = db_mngr
         self._db_url = db_url
         self._db_map = None
+        self._query_iterators = {}
+        self._fetched_ids = {}
         self._current_fetch_token = 0
         self._removed_ids = {}
-        self._query_has_elements_by_key = {}
         self._fetched_item_types = set()
         self.commit_cache = {}
         self._executor = QtBasedThreadPoolExecutor(max_workers=1)
@@ -86,8 +129,8 @@ class SpineDBWorker(QObject):
     @Slot(object, tuple)
     def _handle_something_happened(self, event, args):
         {
-            _Event.FETCH: self._fetch_event,
-            _Event.FETCH_STATUS_CHANGE: self._fetch_status_change_event,
+            _Event.MORE_AVAILABLE: self._more_available_event,
+            _Event.WILL_HAVE_CHILDREN_CHANGE: self._will_have_children_change_event,
             _Event.ADD_ITEMS: self._add_items_event,
             _Event.UPDATE_ITEMS: self._update_items_event,
             _Event.REMOVE_ITEMS: self._remove_items_event,
@@ -112,8 +155,9 @@ class SpineDBWorker(QObject):
     def reset_queries(self):
         """Resets queries and clears caches."""
         self._current_fetch_token += 1
+        self._fetched_ids.clear()
         self._fetched_item_types.clear()
-        self._query_has_elements_by_key.clear()
+        self._query_iterators.clear()
         self._removed_ids.clear()
 
     def _reset_fetching_if_required(self, parent):
@@ -127,6 +171,92 @@ class SpineDBWorker(QObject):
         elif parent.fetch_token != self._current_fetch_token:
             parent.reset_fetching(self._current_fetch_token)
 
+    def advance_query_iterator(self, parent):
+        self._executor.submit(self._advance_query_iterator, parent)
+
+    def _advance_query_iterator(self, parent):
+        if self._do_advance_query_iterator(parent.fetch_item_type):
+            self._something_happened.emit(_Event.MORE_AVAILABLE, (parent,))
+        else:
+            parent.set_fetched(True)
+            parent.set_busy(False)
+
+    @busy_effect
+    @_db_map_lock
+    def _do_advance_query_iterator(self, item_type):
+        if item_type not in self._query_iterators:
+            try:
+                sq_name = self._db_map.cache_sqs[item_type]
+            except KeyError:
+                return False
+            query = self._db_map.query(getattr(self._db_map, sq_name))
+            self._query_iterators[item_type] = _by_chunks(
+                x._asdict() for x in query.yield_per(_CHUNK_SIZE).enable_eagerloads(False)
+            )
+        iterator = self._query_iterators[item_type]
+        chunk = next(iterator, None)
+        if chunk is None:
+            self._fetched_item_types.add(item_type)
+            return False
+        self._fetched_ids.setdefault(item_type, []).extend([x["id"] for x in chunk])
+        self._db_mngr.cache_items(item_type, {self._db_map: chunk})
+        self._populate_commit_cache(item_type, chunk)
+        return True
+
+    def _register_fetch_parent(self, parent):
+        self._parents_by_type.setdefault(parent.fetch_item_type, set()).add(parent)
+        self._update_parents_will_have_children(parent.fetch_item_type)
+
+    def _update_parents_will_have_children(self, item_type):
+        self._executor.submit(self._do_update_parents_will_have_children, item_type)
+
+    def _do_update_parents_will_have_children(self, item_type):
+        parents = self._parents_by_type.get(item_type, ())
+        position = 0
+        while True:
+            parents_to_check = {parent for parent in parents if parent.will_have_children is None}
+            if not parents_to_check:
+                break
+            removed_ids = self._removed_ids.get(item_type, ())
+            for id_ in self._fetched_ids.get(item_type, [])[position:]:
+                if self._parents_by_type.get(item_type, ()) != parents:
+                    # New parents registered - we need to start over
+                    return
+                position += 1
+                if id_ in removed_ids:
+                    continue
+                item = self._db_mngr.get_item(self._db_map, item_type, id_)
+                for parent in parents_to_check.copy():
+                    if parent.accepts_item(item, self._db_map):
+                        parent.will_have_children = True
+                        parents_to_check.remove(parent)
+                if not parents_to_check:
+                    return
+            if not parents_to_check:
+                break
+            if not self._do_advance_query_iterator(item_type):
+                for parent in parents_to_check:
+                    parent.will_have_children = False
+                    self._something_happened.emit(_Event.WILL_HAVE_CHILDREN_CHANGE, (parent,))
+                break
+
+    def _get_cache_iterator(self, parent):
+        if parent.iterator is None:
+            parent.iterator = _CacheIterator(self, parent)
+        return parent.iterator
+
+    def iterate_cache(self, parent, position, set_position):
+        item_type = parent.fetch_item_type
+        removed_ids = self._removed_ids.get(item_type, ())
+        for id_ in self._fetched_ids.get(item_type, [])[position:]:
+            position += 1
+            set_position(position)
+            if id_ in removed_ids:
+                continue
+            item = self._db_mngr.get_item(self._db_map, item_type, id_)
+            if parent.accepts_item(item, self._db_map):
+                yield item
+
     def can_fetch_more(self, parent):
         """Returns whether more data can be fetched for parent.
         Also, registers the parent to notify it of any relevant DB modifications later on.
@@ -137,81 +267,13 @@ class SpineDBWorker(QObject):
         Returns:
             bool: True if more data is available, False otherwise
         """
-        self._parents_by_type.setdefault(parent.fetch_item_type, set()).add(parent)
         self._reset_fetching_if_required(parent)
-        if parent.is_fetched or parent.is_busy_fetching:
-            return False
-        if parent.query_initialized == FetchParent.Init.UNINITIALIZED:
-            parent.query_initialized = FetchParent.Init.IN_PROGRESS
-            self._executor.submit(self._init_query, parent)
-            return True
-        if parent.query_initialized == FetchParent.Init.IN_PROGRESS:
-            return True
-        if parent.query_initialized == FetchParent.Init.FAILED:
-            return False
-        return self._query_has_elements(parent)
-
-    @busy_effect
-    def _init_query(self, parent):
-        """Initializes query for parent.
-
-        Args:
-            parent (FetchParent): fetch parent
-        """
-        lock = self._db_mngr.db_map_locks.get(self._db_map)
-        if lock is None or not lock.tryLock():
-            parent.query_initialized = FetchParent.Init.FAILED
-            return
-        try:
-            self._setdefault_query(parent)
-            if not self._query_has_elements(parent):
-                parent.set_fetched(True)
-                self._something_happened.emit(_Event.FETCH_STATUS_CHANGE, (parent,))
-        finally:
-            parent.query_initialized = FetchParent.Init.FINISHED
-            lock.unlock()
+        self._register_fetch_parent(parent)
+        return parent.will_have_children is not False and not parent.is_fetched and not parent.is_busy
 
     @staticmethod
-    def _fetch_status_change_event(parent):
-        parent.fetch_status_change()
-
-    def _setdefault_query(self, parent):
-        """Creates a query for parent. Stores both the query and whether it has elements.
-
-        Args:
-            parent (FetchParent): fetch parent
-        """
-        if parent.query is None:
-            parent.query = self._make_query_for_parent(parent)
-            self._setdefault_query_key(parent)
-            if parent.query_key not in self._query_has_elements_by_key:
-                self._query_has_elements_by_key[parent.query_key] = bool(parent.query.first())
-        return parent.query
-
-    def _query_has_elements(self, parent):
-        """Checks whether query has something to return.
-
-        Args:
-            parent (FetchParent): fetch parent
-
-        Returns:
-            bool: True if query will give records, False otherwise
-        """
-        return self._query_has_elements_by_key[self._setdefault_query_key(parent)]
-
-    @staticmethod
-    def _setdefault_query_key(parent):
-        """Returns parent's query key or creates and sets a new one if it doesn't exist.
-
-        Args:
-            parent (FetchParent): fetch parent
-
-        Returns:
-            str: query key
-        """
-        if parent.query_key is None:
-            parent.query_key = str(parent.query.statement.compile(compile_kwargs={"literal_binds": True}))
-        return parent.query_key
+    def _will_have_children_change_event(parent):
+        parent.will_have_children_change()
 
     def fetch_more(self, parent):
         """Fetches items from the database.
@@ -219,30 +281,20 @@ class SpineDBWorker(QObject):
         Args:
             parent (FetchParent): fetch parent
         """
-        if parent not in self._parents_by_type.get(parent.fetch_item_type, set()):
+        if parent not in self._parents_by_type.get(parent.fetch_item_type, ()):
             raise RuntimeError(
                 f"attempting to fetch unregistered parent {parent} - did you forget to call ``can_fetch_more()``"
             )
         self._reset_fetching_if_required(parent)
-        parent.set_busy_fetching(True)
-        self._executor.submit(self._fetch_more, parent)
-
-    @busy_effect
-    @_db_map_lock
-    def _fetch_more(self, parent):
-        iterator = self._get_iterator(parent)
-        chunk = next(iterator, [])
-        self._something_happened.emit(_Event.FETCH, (parent, chunk))
-
-    def _fetch_event(self, parent, chunk):
+        parent.set_busy(True)
+        iterator = self._get_cache_iterator(parent)
+        chunk = next(iterator, None)
         if chunk:
-            removed_ids = self._removed_ids.get(parent.fetch_item_type, ())
-            db_map_data = {self._db_map: [item for item in chunk if item["id"] not in removed_ids]}
-            self._db_mngr.cache_items(parent.fetch_item_type, db_map_data)
-            parent.handle_items_added(db_map_data)
-        elif parent.query is not None:
-            parent.set_fetched(True)
-        parent.set_busy_fetching(False)
+            parent.handle_items_added({self._db_map: chunk})
+            parent.set_busy(False)
+
+    def _more_available_event(self, parent):
+        self.fetch_more(parent)
 
     def fetch_all(self, fetch_item_types=None, only_descendants=False, include_ancestors=False):
         if fetch_item_types is None:
@@ -260,51 +312,14 @@ class SpineDBWorker(QObject):
                 for ancestor in self._db_map.ancestor_tablenames.get(item_type, ())
             }
         fetch_item_types -= self._fetched_item_types
-        if not fetch_item_types:
-            # FIXME: Needed? QCoreApplication.processEvents()
-            return
-        _ = self._executor.submit(self._fetch_all, fetch_item_types).result()
+        if fetch_item_types:
+            _ = self._executor.submit(self._fetch_all, fetch_item_types).result()
 
     @busy_effect
-    @_db_map_lock
     def _fetch_all(self, item_types):
         for item_type in item_types:
-            query, _ = self._make_query_for_item_type(item_type)
-            if query is None:
-                continue
-            for chunk in _make_iterator(query):
-                self._populate_commit_cache(item_type, chunk)
-                self._db_mngr.cache_items(item_type, {self._db_map: chunk})
-            self._fetched_item_types.add(item_type)
-
-    def _make_query_for_parent(self, parent):
-        """Makes a database query for given item type.
-
-        Args:
-            parent (object): the object that requests the fetching
-
-        Returns:
-            Query: database query
-        """
-        query, subquery = self._make_query_for_item_type(parent.fetch_item_type)
-        return parent.filter_query(query, subquery, self._db_map)
-
-    def _make_query_for_item_type(self, item_type):
-        try:
-            subquery_name = self._db_map.cache_sqs[item_type]
-        except KeyError:
-            return None, None
-        subquery = getattr(self._db_map, subquery_name)
-        query = self._db_map.query(subquery)
-        return query, subquery
-
-    def _get_iterator(self, parent):
-        if parent.query_iterator is None:
-            # For some reason queries that haven't been iterated before don't
-            # keep up with deleted items. Reset the query here as a workaround.
-            parent.query = self._make_query_for_parent(parent)
-            parent.query_iterator = _make_iterator(self._setdefault_query(parent))
-        return parent.query_iterator
+            while self._do_advance_query_iterator(item_type):
+                pass
 
     def _populate_commit_cache(self, item_type, items):
         if item_type == "commit":
@@ -333,15 +348,12 @@ class SpineDBWorker(QObject):
     def _call_in_parents(self, method_name, item_type, items):
         # TODO: Probably we want to handle RunTimeError set changed size during iteration
         # which may happen when removing parents above?
-        to_remove = set()
         for parent in self._parents_by_type.get(item_type, ()):
             children = [x for x in items if parent.accepts_item(x, self._db_map)]
             if not children:
                 continue
             method = getattr(parent, method_name)
             method({self._db_map: children})
-        for parent in to_remove:
-            self._parents_by_type.get(parent.fetch_item_type).remove(parent)
 
     def _update_special_refs(self, item_type, ids):
         cascading_ids_by_type = self._db_mngr.special_cascading_ids(self._db_map, item_type, ids)
@@ -601,20 +613,3 @@ class SpineDBWorker(QObject):
             self._db_mngr.error_msg.emit({self._db_map: errors})
         else:
             self._db_mngr.session_rolled_back.emit({self._db_map})
-
-
-def _make_iterator(query):
-    """Runs the given query and yields results by chunks of given size.
-
-    Args:
-        query (Query): the query
-
-    Yields:
-        list: chunk of items
-    """
-    it = (x._asdict() for x in query.yield_per(_CHUNK_SIZE).enable_eagerloads(False))
-    while True:
-        chunk = list(itertools.islice(it, _CHUNK_SIZE))
-        yield chunk
-        if not chunk:
-            break

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -247,7 +247,7 @@ class SpineDBWorker(QObject):
         self._update_parents_will_have_children(parent.fetch_item_type)
 
     def _update_parents_will_have_children(self, item_type):
-        """Schedules an restart of the process that checks whether parents associated to given type will have children.
+        """Schedules a restart of the process that checks whether parents associated to given type will have children.
 
         Args:
             item_type (str)
@@ -316,7 +316,7 @@ class SpineDBWorker(QObject):
         Args:
             parent (FetchParent): the parent that requests the items.
             position (int): initial position.
-            set_position (function): a function to call with the new position everytime we iterate.
+            set_position (function): a function to call with the new position every time we iterate.
                 This is so the caller (_CacheIterator) knows where to start the next time it needs items.
 
         Yields:

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -236,7 +236,7 @@ class SpineDBWorker(QObject):
 
     def _fetch_event(self, parent, chunk):
         if chunk:
-            removed_ids = self._removed_ids.get(parent.fetch_item_type)
+            removed_ids = self._removed_ids.get(parent.fetch_item_type, ())
             db_map_data = {self._db_map: [item for item in chunk if item["id"] not in removed_ids]}
             self._db_mngr.cache_items(parent.fetch_item_type, db_map_data)
             parent.handle_items_added(db_map_data)

--- a/tests/spine_db_editor/mvcmodels/test_alternative_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_alternative_scenario_model.py
@@ -160,12 +160,12 @@ class TestAlternativeScenarioModel(unittest.TestCase):
         self.assertTrue(model.setData(index, "perse"))
 
     def test_update_alternatives(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
         model = AlternativeScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         for item in model.visit_all():
             if item.can_fetch_more():
                 item.fetch_more()
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
         self._db_mngr.update_alternatives({self._db_map: [{"id": 2, "name": "renamed"}]})
         data = self._model_data_to_dict(model)
         expected = [
@@ -191,14 +191,14 @@ class TestAlternativeScenarioModel(unittest.TestCase):
         self.assertEqual(data, expected)
 
     def test_update_alternatives_with_scenario_alternatives(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1"}]})
-        self._db_mngr.set_scenario_alternatives({self._db_map: [{"id": 1, "alternative_id_list": "2"}]})
         model = AlternativeScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         for item in model.visit_all():
             if item.can_fetch_more():
                 item.fetch_more()
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1"}]})
+        self._db_mngr.set_scenario_alternatives({self._db_map: [{"id": 1, "alternative_id_list": "2"}]})
         self._db_mngr.update_alternatives({self._db_map: [{"id": 2, "name": "renamed"}]})
         self._db_mngr.update_alternatives({self._db_map: [{"id": 2}]})
         self._db_mngr.update_scenarios({self._db_map: [{"id": 1, "alternative_id_list": "2"}]})
@@ -250,12 +250,12 @@ class TestAlternativeScenarioModel(unittest.TestCase):
         self.assertEqual(data, expected)
 
     def test_remove_alternatives(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
         model = AlternativeScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         for item in model.visit_all():
             if item.can_fetch_more():
                 item.fetch_more()
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
         self._db_mngr.remove_items({self._db_map: {"alternative": {2}}})
         data = self._model_data_to_dict(model)
         expected = [

--- a/tests/spine_db_editor/mvcmodels/test_compound_parameter_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_compound_parameter_models.py
@@ -70,10 +70,10 @@ class TestCompoundObjectParameterDefinitionModel(unittest.TestCase):
     def test_data_for_single_parameter_definition(self):
         model = CompoundObjectParameterDefinitionModel(self._db_editor, self._db_mngr, self._db_map)
         model.init_model()
-        self._db_mngr.add_object_classes({self._db_map: [{"name": "oc"}]})
-        self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "object_class_id": 1}]})
         if model.canFetchMore(None):
             model.fetchMore(None)
+        self._db_mngr.add_object_classes({self._db_map: [{"name": "oc"}]})
+        self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "object_class_id": 1}]})
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.columnCount(), 6)
         row = [model.index(0, column).data() for column in range(model.columnCount())]

--- a/tests/spine_db_editor/widgets/test_SpineDBEditor.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditor.py
@@ -329,21 +329,25 @@ class TestSpineDBEditor(
         """Put fish and dog object classes in the db mngr."""
         object_classes = [self.fish_class, self.dog_class]
         self.db_mngr.add_object_classes({self.mock_db_map: object_classes})
+        self.fetch_object_tree_model()
 
     def put_mock_objects_in_db_mngr(self):
         """Put nemo, pluto and scooby objects in the db mngr."""
         objects = [self.nemo_object, self.pluto_object, self.scooby_object]
         self.db_mngr.add_objects({self.mock_db_map: objects})
+        self.fetch_object_tree_model()
 
     def put_mock_relationship_classes_in_db_mngr(self):
         """Put dog__fish and fish__dog relationship classes in the db mngr."""
         relationship_classes = [self.fish_dog_class, self.dog_fish_class]
         self.db_mngr.add_relationship_classes({self.mock_db_map: relationship_classes})
+        self.fetch_object_tree_model()
 
     def put_mock_relationships_in_db_mngr(self):
         """Put pluto_nemo, nemo_pluto and nemo_scooby relationships in the db mngr."""
         relationships = [self.pluto_nemo_rel, self.nemo_pluto_rel, self.nemo_scooby_rel]
         self.db_mngr.add_relationships({self.mock_db_map: relationships})
+        self.fetch_object_tree_model()
 
     def put_mock_object_parameter_definitions_in_db_mngr(self):
         """Put water and breed object parameter definitions in the db mngr."""
@@ -383,7 +387,6 @@ class TestSpineDBEditor(
         self.put_mock_relationship_parameter_definitions_in_db_mngr()
         self.put_mock_object_parameter_values_in_db_mngr()
         self.put_mock_relationship_parameter_values_in_db_mngr()
-        self.fetch_object_tree_model()
 
     def fetch_object_tree_model(self):
         for item in self.spine_db_editor.object_tree_model.visit_all():

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorAdd.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorAdd.py
@@ -55,10 +55,10 @@ class TestSpineDBEditorAddMixin:
     def test_add_relationship_classes_to_object_tree_model(self):
         """Test that relationship classes are added to the object tree model."""
         self.spine_db_editor.init_models()
+        self.fetch_object_tree_model()
         self.put_mock_object_classes_in_db_mngr()
         self.put_mock_objects_in_db_mngr()
         self.put_mock_relationship_classes_in_db_mngr()
-        self.fetch_object_tree_model()
         root_item = self.spine_db_editor.object_tree_model.root_item
         dog_item, fish_item = root_item.children
         nemo_item = fish_item.child(0)
@@ -114,13 +114,13 @@ class TestSpineDBEditorAddMixin:
 
     def test_add_object_parameter_definitions_to_model(self):
         """Test that object parameter definitions are added to the model."""
+        model = self.spine_db_editor.object_parameter_definition_model
+        if model.canFetchMore(None):
+            model.fetchMore(None)
         self.put_mock_object_classes_in_db_mngr()
         with mock.patch.object(SingleParameterModel, "__lt__") as lt_mocked:
             lt_mocked.return_value = False
             self.put_mock_object_parameter_definitions_in_db_mngr()
-        model = self.spine_db_editor.object_parameter_definition_model
-        if model.canFetchMore(None):
-            model.fetchMore(None)
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):
@@ -132,14 +132,14 @@ class TestSpineDBEditorAddMixin:
 
     def test_add_relationship_parameter_definitions_to_model(self):
         """Test that relationship parameter definitions are added to the model."""
+        model = self.spine_db_editor.relationship_parameter_definition_model
+        if model.canFetchMore(None):
+            model.fetchMore(None)
         self.put_mock_object_classes_in_db_mngr()
         self.put_mock_relationship_classes_in_db_mngr()
         with mock.patch.object(SingleParameterModel, "__lt__") as lt_mocked:
             lt_mocked.return_value = False
             self.put_mock_relationship_parameter_definitions_in_db_mngr()
-        model = self.spine_db_editor.relationship_parameter_definition_model
-        if model.canFetchMore(None):
-            model.fetchMore(None)
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):
@@ -151,15 +151,15 @@ class TestSpineDBEditorAddMixin:
 
     def test_add_object_parameter_values_to_model(self):
         """Test that object parameter values are added to the model."""
+        model = self.spine_db_editor.object_parameter_value_model
+        if model.canFetchMore(None):
+            model.fetchMore(None)
         self.put_mock_object_classes_in_db_mngr()
         self.put_mock_objects_in_db_mngr()
         self.put_mock_object_parameter_definitions_in_db_mngr()
         with mock.patch.object(SingleParameterModel, "__lt__") as lt_mocked:
             lt_mocked.return_value = False
             self.put_mock_object_parameter_values_in_db_mngr()
-        model = self.spine_db_editor.object_parameter_value_model
-        if model.canFetchMore(None):
-            model.fetchMore(None)
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):
@@ -176,6 +176,9 @@ class TestSpineDBEditorAddMixin:
 
     def test_add_relationship_parameter_values_to_model(self):
         """Test that object parameter values are added to the model."""
+        model = self.spine_db_editor.relationship_parameter_value_model
+        if model.canFetchMore(None):
+            model.fetchMore(None)
         self.put_mock_object_classes_in_db_mngr()
         self.put_mock_objects_in_db_mngr()
         self.put_mock_relationship_classes_in_db_mngr()
@@ -185,9 +188,6 @@ class TestSpineDBEditorAddMixin:
         with mock.patch.object(SingleParameterModel, "__lt__") as lt_mocked:
             lt_mocked.return_value = False
             self.put_mock_relationship_parameter_values_in_db_mngr()
-        model = self.spine_db_editor.relationship_parameter_value_model
-        if model.canFetchMore(None):
-            model.fetchMore(None)
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
@@ -57,10 +57,10 @@ class TestSpineDBEditorFilterMixin:
 
     def test_filter_parameter_tables_per_object_class(self):
         """Test that parameter tables are filtered when selecting object classes in the object tree."""
-        self.put_mock_dataset_in_db_mngr()
         for model in self._filtered_fields:
             if model.canFetchMore(None):
                 model.fetchMore(None)
+        self.put_mock_dataset_in_db_mngr()
         root_item = self.spine_db_editor.object_tree_model.root_item
         fish_item = root_item.child(1)
         fish_index = self.spine_db_editor.object_tree_model.index_from_item(fish_item)
@@ -77,10 +77,10 @@ class TestSpineDBEditorFilterMixin:
 
     def test_filter_parameter_tables_per_object(self):
         """Test that parameter tables are filtered when selecting objects in the object tree."""
-        self.put_mock_dataset_in_db_mngr()
         for model in self._filtered_fields:
             if model.canFetchMore(None):
                 model.fetchMore(None)
+        self.put_mock_dataset_in_db_mngr()
         root_item = self.spine_db_editor.object_tree_model.root_item
         dog_item = root_item.child(0)
         pluto_item = dog_item.child(0)
@@ -98,10 +98,10 @@ class TestSpineDBEditorFilterMixin:
 
     def test_filter_parameter_tables_per_relationship_class(self):
         """Test that parameter tables are filtered when selecting relationship classes in the object tree."""
-        self.put_mock_dataset_in_db_mngr()
         for model in self._filtered_fields:
             if model.canFetchMore(None):
                 model.fetchMore(None)
+        self.put_mock_dataset_in_db_mngr()
         root_item = self.spine_db_editor.object_tree_model.root_item
         dog_item = root_item.child(0)
         pluto_item = dog_item.child(0)
@@ -120,10 +120,10 @@ class TestSpineDBEditorFilterMixin:
 
     def test_filter_parameter_tables_per_relationship(self):
         """Test that parameter tables are filtered when selecting relationships in the object tree."""
-        self.put_mock_dataset_in_db_mngr()
         for model in self._filtered_fields:
             if model.canFetchMore(None):
                 model.fetchMore(None)
+        self.put_mock_dataset_in_db_mngr()
         root_item = self.spine_db_editor.object_tree_model.root_item
         dog_item = root_item.child(0)
         pluto_item = dog_item.child(0)

--- a/tests/spine_db_editor/widgets/test_custom_qtreeview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtreeview.py
@@ -908,14 +908,14 @@ class TestToolFeatureTreeViewWithInitiallyEmptyDatabase(TestBase):
 
     def test_add_tool_feature(self):
         self._add_parameter_with_value_list()
-        self._add_feature()
-        self._add_tool()
-        self._add_tool_feature()
         view = self._db_editor.ui.treeView_tool_feature
         model = view.model()
         for item in model.visit_all():
             if item.can_fetch_more():
                 item.fetch_more()
+        self._add_feature()
+        self._add_tool()
+        self._add_tool_feature()
         db_index = model.index(0, 0)
         tool_root_index = model.index(1, 0, db_index)
         tool_index = model.index(0, 0, tool_root_index)
@@ -975,6 +975,9 @@ class TestToolFeatureTreeViewWithInitiallyEmptyDatabase(TestBase):
         feature_index = model.index(0, 0, feature_root_index)
         view_edit = EditorDelegateMocking()
         view_edit.write_to_index(view, feature_index, "my_object_class/my_parameter")
+        for item in model.visit_all():
+            if item.can_fetch_more():
+                item.fetch_more()
 
     def _add_tool(self):
         view = self._db_editor.ui.treeView_tool_feature
@@ -984,6 +987,9 @@ class TestToolFeatureTreeViewWithInitiallyEmptyDatabase(TestBase):
         tool_index = model.index(0, 0, tool_root_index)
         view_edit = EditorDelegateMocking()
         view_edit.write_to_index(view, tool_index, "my_tool")
+        for item in model.visit_all():
+            if item.can_fetch_more():
+                item.fetch_more()
 
     def _add_tool_feature(self):
         view = self._db_editor.ui.treeView_tool_feature
@@ -995,6 +1001,9 @@ class TestToolFeatureTreeViewWithInitiallyEmptyDatabase(TestBase):
         tool_feature_index = model.index(0, 0, tool_feature_root_index)
         view_edit = EditorDelegateMocking()
         view_edit.write_to_index(view, tool_feature_index, "my_object_class/my_parameter")
+        for item in model.visit_all():
+            if item.can_fetch_more():
+                item.fetch_more()
 
 
 class TestToolFeatureTreeViewWithExistingData(TestBase):


### PR DESCRIPTION
The idea here is to reduce querying from the DB to the bare minimum. Previously, whenever items needed to fetch data they would always go to the database even if the data was already in the cache.

This PR introduces a new system where there is only one query per table that fetches items from the DB and puts them in the cache. Items that need data would fetch it first from cache, and whenever the cache is exhausted, it will trigger a progression of the DB query for the corresponding table to get new items into cache.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
