### PR TITLE
Remove project dir after remote execution

### DIFF
--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -1443,8 +1443,7 @@ class SpineToolboxProject(MetaObject):
         return job_id
 
     def finalize_remote_execution(self):
-        """Sends a request to server to remove the project folder. Also,
-        removes the zipped project file from client."""
+        """Sends a request to server to remove the project directory and removes the project ZIP file from client."""
         if not self._settings.value("engineSettings/remoteExecutionEnabled", defaultValue="false") == "true":
             return
         host, port, sec_model, sec_folder = self._toolbox.engine_server_settings()
@@ -1455,15 +1454,13 @@ class SpineToolboxProject(MetaObject):
                 f"Server is not responding. {e}. " f"Check settings in <b>File->Settings->Engine</b>."
             )
             return
-        response = engine_client.remove_project_from_server(self.job_id)
-        self._logger.msg.emit(f"remove_project_from_server response:{response}")
+        engine_client.remove_project_from_server(self.job_id)
         engine_client.close()
-        # Remove the uploaded project ZIP file
         project_zip_file = os.path.abspath(os.path.join(self.project_dir, os.pardir, PROJECT_ZIP_FILENAME + ".zip"))
         if not os.path.isfile(project_zip_file):
             return
         try:
-            os.remove(project_zip_file)
+            os.remove(project_zip_file)  # Remove the uploaded project ZIP file
         except OSError:
             self._logger.msg_warning.emit(f"[OSError] Removing ZIP file {project_zip_file} failed. "
                                           f"Please remove it manually.")

--- a/spinetoolbox/server/engine_client.py
+++ b/spinetoolbox/server/engine_client.py
@@ -250,7 +250,7 @@ class EngineClient:
         return response[-1]
 
     def remove_project_from_server(self, job_id):
-        """Removes a project directory from server.
+        """Sends a request to remove a project directory from server.
 
         Args:
             job_id (str): Job Id for finding the project directory on server

--- a/spinetoolbox/server/engine_client.py
+++ b/spinetoolbox/server/engine_client.py
@@ -249,6 +249,20 @@ class EngineClient:
         response = self.dealer_socket.recv_multipart()
         return response[-1]
 
+    def remove_project_from_server(self, job_id):
+        """Removes a project directory from server.
+
+        Args:
+            job_id (str): Job Id for finding the project directory on server
+
+        Returns:
+            str: Message from server
+        """
+        req = ServerMessage("remove_project", job_id, "")
+        self.dealer_socket.send_multipart([req.to_bytes()])
+        response = self.dealer_socket.recv_multipart()
+        return response[-1]
+
     def send_is_complete(self, persistent_key, cmd):
         """Sends a request to process is_complete(cmd) in persistent manager on server and returns the response."""
         data = persistent_key, "is_complete", cmd

--- a/tests/server/test_EngineClient.py
+++ b/tests/server/test_EngineClient.py
@@ -165,6 +165,15 @@ class TestEngineClient(unittest.TestCase):
         self.assertTrue(len(job_id) == 32)
         client.close()
 
+    def test_remove_project_from_server(self):
+        project_zip_fpath = os.path.join(str(Path(__file__).parent), "helloworld.zip")
+        client = EngineClient("localhost", 5601, ClientSecurityModel.NONE, "")
+        job_id = client.upload_project("Hello World", project_zip_fpath)
+        self.assertTrue(isinstance(job_id, str))
+        self.assertTrue(len(job_id) == 32)
+        client.remove_project_from_server(job_id)
+        client.close()
+
     # def test_start_execution(self):
     #     project_zip_fpath = os.path.join(str(Path(__file__).parent), "helloworld.zip")
     #     client = EngineClient("localhost", 5601, ClientSecurityModel.NONE, "")

--- a/tests/widgets/test_AboutWidget.py
+++ b/tests/widgets/test_AboutWidget.py
@@ -17,9 +17,8 @@ Unit tests for the AboutWidget class.
 """
 
 import unittest
-from PySide2.QtWidgets import QApplication
+from PySide2.QtWidgets import QApplication, QWidget
 from spinetoolbox.widgets.about_widget import AboutWidget
-from tests.mock_helpers import create_toolboxui, clean_up_toolbox
 
 
 class TestAboutWidget(unittest.TestCase):
@@ -29,22 +28,21 @@ class TestAboutWidget(unittest.TestCase):
             QApplication()
 
     def setUp(self):
-        self.toolbox = create_toolboxui()
         self._original_clip = QApplication.clipboard().text()
 
     def tearDown(self):
-        clean_up_toolbox(self.toolbox)
         QApplication.clipboard().setText(self._original_clip)
 
     def test_constructor(self):
-        w = AboutWidget(self.toolbox)
+        w = AboutWidget(QWidget())
         self.assertIsInstance(w, AboutWidget)
         w.close()
 
     def test_copy_to_clipboard(self):
-        w = AboutWidget(self.toolbox)
+        w = AboutWidget(QWidget())
         w.copy_to_clipboard(True)
         cb_contents = QApplication.clipboard().text()
+        # Note: clipboard tests may break if other apps (eg. VMs in Virtual Box) reserve the system clipboard
         self.assertTrue("Python" in cb_contents)
         w.close()
 


### PR DESCRIPTION
Sends a request to server to remove project directory after remote execution.

Resolves #1833

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [x] Unit tests pass
