### PR TITLE
Require matplotlib>=3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,11 +39,7 @@ install_requires =
     spinedb_api >=0.24.0
     spine_engine >=0.19.0
     numpy >=1.20.2
-    matplotlib >=3.0, !=3.2.1, !=3.3.1
-    # matplotlib == 3.2.1 is broken; importing e.g. networkx after matplotlib.backends.backend_qt5agg backtraces
-    # also, matplotlib == 3.2.1 requires shiboken2 but does not list it in its dependencies
-    # matplotlib 3.3.1 fails to install properly from pip, see
-    # https://stackoverflow.com/questions/24251102/from-matplotlib-import-ft2font-importerror-dll-load-failed-the-specified-pro/24251889#24251889
+    matplotlib >= 3.5
     scipy >=1.7.1
     networkx >=2.6
     pandas >=1.3.2


### PR DESCRIPTION
Makes sure latest plotting works.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
