### PR TITLE
Notify Python 3.7 users to upgrade

### DIFF
--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -17,6 +17,7 @@ Contains ToolboxUI class.
 """
 
 import os
+import platform
 import sys
 import locale
 import logging
@@ -231,6 +232,19 @@ class ToolboxUI(QMainWindow):
         self.set_work_directory()
         self._disable_project_actions()
         self.connect_signals()
+        if self.python_version_is_37():
+            msg = "Python 3.7 support will be dropped in the near future. " \
+                  "Please install Spine Toolbox on Python 3.8 or greater."
+            logging.warning(msg)
+            self.msg_warning.emit(msg)
+
+    def python_version_is_37(self):
+        """Returns True if on Python 3.7, False Otherwise.
+        Remove when PySide6 port is in master."""
+        v = platform.python_version_tuple()
+        if v[0] == "3" and v[1] == "7":
+            return True
+        return False
 
     def eventFilter(self, obj, ev):
         # Save/restore splitter states when hiding/showing execution lists


### PR DESCRIPTION
This PR prints a note to stdout and to Toolbox's Event Log that Python 3.7 support will be dropped soon.

Fixes #1903

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
