### PR TITLE
Use shared item lock in unit tests

### DIFF
--- a/tests/test_spineToolboxProject.py
+++ b/tests/test_spineToolboxProject.py
@@ -645,7 +645,7 @@ class _MockExecutableItem(ExecutableItemBase):
     def ready_to_execute(self, _settings):
         return True
 
-    def execute(self, _forward_resources, _backward_resources):
+    def execute(self, _forward_resources, _backward_resources, lock):
         self.execute_called = True
         return ItemExecutionFinishState.SUCCESS
 


### PR DESCRIPTION
PRs Spine-project/spine-engine#72 and Spine-project/spine-items#80 introduce a new argument to execute() and exclude_execution() methods. This fixes broken unit tests on Toolbox' side.

Fixes irena-flextool/flextool#30

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
~- [] Unit tests pass~ Won't pass due to changes in executable item base class in Spine Engine
