### PR TITLE
Bail out if there are no DAGs to execute

### DIFF
--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -958,6 +958,9 @@ class SpineToolboxProject(MetaObject):
             execution_permits_list (Sequence(dict))
             msg (str): message to log before execution
         """
+        if not dags:
+            self._logger.msg.emit("Nothing to execute.")
+            return
         self.project_execution_about_to_start.emit()
         self._logger.msg.emit("")
         self._logger.msg.emit("-------------------------------------------------")
@@ -1108,8 +1111,7 @@ class SpineToolboxProject(MetaObject):
         valid = []
         for dag in dags:
             if not dag.nodes:
-                # Should never happen
-                continue
+                raise RuntimeError("Logic error: DAG should never have no nodes.")
             if not nx.is_directed_acyclic_graph(dag):
                 items = ", ".join(dag.nodes)
                 self._logger.msg_error.emit(f"<b>Skipping execution of items as they are in a cycle: {items}</b>")

--- a/tests/test_spineToolboxProject.py
+++ b/tests/test_spineToolboxProject.py
@@ -308,6 +308,18 @@ class TestSpineToolboxProject(unittest.TestCase):
         self.assertFalse(item1_executable.execute_called)
         self.assertTrue(item2_executable.execute_called)
 
+    def test_executing_cyclic_dag_fails_graciously(self):
+        item1 = add_dc(self.toolbox.project(), self.toolbox.item_factories, "DC")
+        item2 = add_view(self.toolbox.project(), self.toolbox.item_factories, "View")
+        self.toolbox.project().add_connection(
+            LoggingConnection(item1.name, "right", item2.name, "left", toolbox=self.toolbox)
+        )
+        self.toolbox.project().add_connection(
+            LoggingConnection(item2.name, "bottom", item1.name, "top", toolbox=self.toolbox)
+        )
+        self.toolbox.project().execute_project()
+        self.assertFalse(self.toolbox.project()._execution_in_progress)
+
     def test_change_name(self):
         """Tests renaming a project."""
         new_name = "New Project Name"


### PR DESCRIPTION
This prevents Toolbox ending in a state where it thinks something is being executed while nothing is actually going on.

Fixes #1921

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
