### PR TITLE
Fix add/update SpineOpt wizard in Settings -> Tools

### DIFF
--- a/spinetoolbox/config.py
+++ b/spinetoolbox/config.py
@@ -24,7 +24,7 @@ from pathlib import Path
 LATEST_PROJECT_VERSION = 9
 
 # For the Add/Update SpineOpt wizard
-REQUIRED_SPINE_OPT_VERSION = "0.5.3"
+REQUIRED_SPINE_OPT_VERSION = "0.6.9"
 
 # Invalid characters for directory names
 # NOTE: "." is actually valid in a directory name but this is

--- a/spinetoolbox/widgets/add_up_spine_opt_wizard.py
+++ b/spinetoolbox/widgets/add_up_spine_opt_wizard.py
@@ -170,10 +170,11 @@ class CheckPreviousInstallPage(QWizardPage):
             f"--project={julia_project}",
             "-e",
             'import Pkg; '
-            'manifest = joinpath(dirname(Base.active_project()), "Manifest.toml");'
+            'manifest = joinpath(dirname(Base.active_project()), "Manifest.toml"); '
             'pkgs = isfile(manifest) ? Pkg.TOML.parsefile(manifest) : Dict(); '
-            'spine_opt = get(pkgs, "SpineOpt", nothing); '
-            'if spine_opt != nothing println(spine_opt[1]["version"]) end',
+            'manifest_format = get(pkgs, "manifest_format", missing); '
+            'if manifest_format === missing spine_opt = get(pkgs, "SpineOpt", nothing) else spine_opt = get(pkgs["deps"], "SpineOpt", nothing) end; '
+            'if spine_opt != nothing println(spine_opt[1]["version"]) end; '
         ]
         self._exec_mngr = QProcessExecutionManager(self, julia_exe, args, silent=True)
         self.completeChanged.emit()

--- a/spinetoolbox/widgets/add_up_spine_opt_wizard.py
+++ b/spinetoolbox/widgets/add_up_spine_opt_wizard.py
@@ -173,7 +173,9 @@ class CheckPreviousInstallPage(QWizardPage):
             'manifest = joinpath(dirname(Base.active_project()), "Manifest.toml"); '
             'pkgs = isfile(manifest) ? Pkg.TOML.parsefile(manifest) : Dict(); '
             'manifest_format = get(pkgs, "manifest_format", missing); '
-            'if manifest_format === missing spine_opt = get(pkgs, "SpineOpt", nothing) else spine_opt = get(pkgs["deps"], "SpineOpt", nothing) end; '
+            'if manifest_format === missing '
+            'spine_opt = get(pkgs, "SpineOpt", nothing) '
+            'else spine_opt = get(pkgs["deps"], "SpineOpt", nothing) end; '
             'if spine_opt != nothing println(spine_opt[1]["version"]) end; ',
         ]
         self._exec_mngr = QProcessExecutionManager(self, julia_exe, args, silent=True)

--- a/spinetoolbox/widgets/add_up_spine_opt_wizard.py
+++ b/spinetoolbox/widgets/add_up_spine_opt_wizard.py
@@ -174,7 +174,7 @@ class CheckPreviousInstallPage(QWizardPage):
             'pkgs = isfile(manifest) ? Pkg.TOML.parsefile(manifest) : Dict(); '
             'manifest_format = get(pkgs, "manifest_format", missing); '
             'if manifest_format === missing spine_opt = get(pkgs, "SpineOpt", nothing) else spine_opt = get(pkgs["deps"], "SpineOpt", nothing) end; '
-            'if spine_opt != nothing println(spine_opt[1]["version"]) end; '
+            'if spine_opt != nothing println(spine_opt[1]["version"]) end; ',
         ]
         self._exec_mngr = QProcessExecutionManager(self, julia_exe, args, silent=True)
         self.completeChanged.emit()


### PR DESCRIPTION
Manifest.toml format changed in Julia 1.7, which meant that SpineOpt version check did not work in the app anymore. The version check now works on both older and newer Julia's. Updated REQUIRED_SPINE_OPT_VERSION constant to 0.6.9, which enables upgrading older SpineOpt's to v0.6.9.

Fixes issue #1923

## Checklist before merging
- [x] Documentation is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
