### PR TITLE
Make new filter handling user-settable

### DIFF
--- a/spinetoolbox/project_commands.py
+++ b/spinetoolbox/project_commands.py
@@ -453,6 +453,27 @@ class SetFiltersOnlineCommand(SpineToolboxCommand):
         self._resource_filter_model.set_online(self._resource, self._filter_type, negated_online)
 
 
+class SetConnectionDefaultFilterOnlineStatus(SpineToolboxCommand):
+    """Command to set connection's default filter online status."""
+
+    def __init__(self, connection, default_status):
+        """
+        Args:
+            connection (LoggingConnection): connection
+            default_status (bool): default filter online status
+        """
+        super().__init__()
+        self.setText(f"change options in connection {connection.name}")
+        self._connection = connection
+        self._checked = default_status
+
+    def redo(self):
+        self._connection.set_filter_default_online_status(self._checked)
+
+    def undo(self):
+        self._connection.set_filter_default_online_status(not self._checked)
+
+
 class SetConnectionOptionsCommand(SpineToolboxCommand):
     def __init__(self, connection, options):
         """Command to set connection options.

--- a/spinetoolbox/ui/link_properties.py
+++ b/spinetoolbox/ui/link_properties.py
@@ -47,6 +47,17 @@ class Ui_Form(object):
         self.frame.setFrameShadow(QFrame.Raised)
         self.verticalLayout_2 = QVBoxLayout(self.frame)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.horizontalLayout_3 = QHBoxLayout()
+        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
+        self.auto_check_filters_check_box = QCheckBox(self.frame)
+        self.auto_check_filters_check_box.setObjectName(u"auto_check_filters_check_box")
+        self.auto_check_filters_check_box.setChecked(True)
+
+        self.horizontalLayout_3.addWidget(self.auto_check_filters_check_box)
+
+
+        self.verticalLayout_2.addLayout(self.horizontalLayout_3)
+
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.label_write_index = QLabel(self.frame)
@@ -108,6 +119,7 @@ class Ui_Form(object):
 
     def retranslateUi(self, Form):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
+        self.auto_check_filters_check_box.setText(QCoreApplication.translate("Form", u"Check new filters automatically", None))
         self.label_write_index.setText(QCoreApplication.translate("Form", u"Write index (lower writes earlier):", None))
         self.checkBox_purge_before_writing.setText(QCoreApplication.translate("Form", u"Purge before writing", None))
 #if QT_CONFIG(tooltip)

--- a/spinetoolbox/ui/link_properties.ui
+++ b/spinetoolbox/ui/link_properties.ui
@@ -49,6 +49,20 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="auto_check_filters_check_box">
+          <property name="text">
+           <string>Check new filters automatically</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_write_index">
@@ -143,7 +157,7 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../items/spine_items/ui/resources/resources_icons.qrc"/>
+  <include location="../../../spine-items/spine_items/ui/resources/resources_icons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/tests/project_item/test_logging_connection.py
+++ b/tests/project_item/test_logging_connection.py
@@ -9,6 +9,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 """Unit tests for the ``logging_connection`` module."""
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import MagicMock
@@ -17,7 +18,9 @@ from PySide2.QtGui import QColor
 from PySide2.QtWidgets import QApplication
 
 from spine_engine.project_item.project_item_resource import database_resource
+from spine_engine.project_item.connection import FilterSettings
 from spinedb_api.filters.scenario_filter import SCENARIO_FILTER_TYPE
+from spinetoolbox.helpers import signal_waiter
 from spinetoolbox.project_item.logging_connection import LoggingConnection
 from spinetoolbox.project_item.project_item import ProjectItem
 from spinetoolbox.project_item.project_item_factory import ProjectItemFactory
@@ -29,9 +32,9 @@ from tests.mock_helpers import create_toolboxui_with_project, clean_up_toolbox
 class TestLoggingConnection(unittest.TestCase):
     def test_replace_resource_from_source(self):
         toolbox = MagicMock()
-        disabled_filters = {"database": {"scenario_filter": {"Base"}}}
+        filter_settings = FilterSettings({"database": {"scenario_filter": {"Base": False}}})
         connection = LoggingConnection(
-            "source", "bottom", "destination", "top", toolbox=toolbox, disabled_filter_names=disabled_filters
+            "source", "bottom", "destination", "top", toolbox=toolbox, filter_settings=filter_settings
         )
         connection.link = MagicMock()
         original = database_resource("source", "sqlite:///db.sqlite", label="database", filterable=True)
@@ -40,17 +43,24 @@ class TestLoggingConnection(unittest.TestCase):
         modified = database_resource("source", "sqlite:///db2.sqlite", label="new database", filterable=True)
         connection.replace_resources_from_source([original], [modified])
         self.assertEqual(connection.database_resources, {modified})
-        self.assertEqual(connection._disabled_filter_names, {"new database": {"scenario_filter": {"Base"}}})
+        self.assertEqual(
+            connection._filter_settings.known_filters, {"new database": {"scenario_filter": {"Base": False}}}
+        )
         connection.tear_down()
 
-    def test_set_online(self):
+    def test_set_filter_default_online_status(self):
         toolbox = MagicMock()
-        disabled_filters = {"label": {"scenario_filter": {"Base"}}}
+        filter_settings = FilterSettings()
         connection = LoggingConnection(
-            "source", "bottom", "destination", "top", toolbox=toolbox, disabled_filter_names=disabled_filters
+            "source", "bottom", "destination", "top", toolbox=toolbox, filter_settings=filter_settings
         )
-        connection.set_online("label", "scenario_filter", {"Base": True})
-        self.assertEqual(connection.disabled_filter_names("label", "scenario_filter"), set())
+        toolbox.active_link_item = connection
+        toolbox.link_properties_widgets = {LoggingConnection: MagicMock()}
+        connection.link = MagicMock()
+        self.assertTrue(connection.is_filter_online_by_default)
+        connection.set_filter_default_online_status(False)
+        self.assertFalse(connection.is_filter_online_by_default)
+        toolbox.link_properties_widgets[LoggingConnection].set_auto_check_filters_state.assert_called_with(False)
         connection.tear_down()
 
 
@@ -83,6 +93,62 @@ class TestLoggingConnectionWithToolbox(unittest.TestCase):
             project.remove_connection(connection)
         except KeyError:
             self.fail("remove_connection raised")
+        connection.tear_down()
+
+
+class TestLoggingConnectionWithDatabaseManager(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._temp_dir = TemporaryDirectory()
+        self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
+        self._toolbox.item_factories[_DataStore.item_type()] = _DataStoreFactory
+        self._toolbox._item_properties_uis[_DataStore.item_type()] = _DataStoreFactory.make_properties_widget(self)
+        project = self._toolbox.project()
+        store_1 = _DataStore("Store 1", project)
+        project.add_item(store_1)
+        store_2 = _DataStore("Store 2", project)
+        project.add_item(store_2)
+        self._db_mngr_logger = MagicMock()
+        self._url = "sqlite:///" + str(Path(self._temp_dir.name, "test_database.sqlite"))
+        self._db_map = self._toolbox.db_mngr.get_db_map(
+            self._url, self._db_mngr_logger, codename="database", create=True
+        )
+
+    def tearDown(self):
+        clean_up_toolbox(self._toolbox)
+        self._temp_dir.cleanup()
+
+    def test_has_filters_when_database_has_an_unknown_scenario(self):
+        with signal_waiter(self._toolbox.db_mngr.items_added) as waiter:
+            self._toolbox.db_mngr.add_scenarios({self._db_map: [{"name": "Base", "id": 1}]})
+            waiter.wait()
+        connection = LoggingConnection("Store 1", "right", "Store 2", "left", toolbox=self._toolbox)
+        connection.link = MagicMock()
+        connection.receive_resources_from_source(
+            [database_resource("Store 1", self._url, label="database@Store 1", filterable=True)]
+        )
+        self.assertTrue(connection.has_filters())
+        connection.tear_down()
+
+    def test_set_online(self):
+        with signal_waiter(self._toolbox.db_mngr.items_added) as waiter:
+            self._toolbox.db_mngr.add_scenarios({self._db_map: [{"name": "Base", "id": 1}]})
+            waiter.wait()
+        filter_settings = FilterSettings({"database@Store 1": {"scenario_filter": {"Base": False}}})
+        connection = LoggingConnection(
+            "Store 1", "bottom", "Store 2", "top", toolbox=self._toolbox, filter_settings=filter_settings
+        )
+        connection.link = MagicMock()
+        connection.receive_resources_from_source(
+            [database_resource("Store 1", self._url, label="database@Store 1", filterable=True)]
+        )
+        connection.set_online("database@Store 1", "scenario_filter", {"Base": True})
+        self.assertEqual(connection.online_filters("database@Store 1", "scenario_filter"), {"Base": True})
+        connection.tear_down()
 
 
 class _DataStoreFactory(ProjectItemFactory):

--- a/tests/test_graphics_items.py
+++ b/tests/test_graphics_items.py
@@ -201,7 +201,7 @@ class TestLink(unittest.TestCase):
         self.assertEqual(scenario_item.index().data(), "scenario")
         scenario_index = filter_model.indexFromItem(scenario_item)
         filter_model.setData(scenario_index, Qt.Checked, role=Qt.CheckStateRole)
-        self.assertEqual(self._link.connection.disabled_filter_names("my_database", "scenario_filter"), set())
+        self.assertEqual(self._link.connection.online_filters("my_database", "scenario_filter"), {"scenario": True})
 
     def test_tool_filter_gets_added_to_filter_model(self):
         url = "sqlite:///" + os.path.join(self._temp_dir.name, "db.sqlite")
@@ -231,7 +231,7 @@ class TestLink(unittest.TestCase):
         self.assertEqual(tool_item.index().data(), "tool")
         tool_index = filter_model.indexFromItem(tool_item)
         filter_model.setData(tool_index, Qt.Checked, role=Qt.CheckStateRole)
-        self.assertEqual(self._link.connection.disabled_filter_names("my_database", "scenario_filter"), set())
+        self.assertEqual(self._link.connection.online_filters("my_database", "scenario_filter"), {})
 
     def test_toggle_scenario_filter(self):
         url = "sqlite:///" + os.path.join(self._temp_dir.name, "db.sqlite")
@@ -243,7 +243,7 @@ class TestLink(unittest.TestCase):
         self._link.connection.refresh_resource_filter_model()
         filter_model = self._link.connection.resource_filter_model
         filter_model.set_online(url, "scenario_filter", {1: True})
-        self.assertEqual(self._link.connection.disabled_filter_names(url, "scenario_filter"), set())
+        self.assertEqual(self._link.connection.online_filters(url, "scenario_filter"), {"scenario": True})
 
     def test_toggle_tool_filter(self):
         url = "sqlite:///" + os.path.join(self._temp_dir.name, "db.sqlite")
@@ -255,7 +255,7 @@ class TestLink(unittest.TestCase):
         self._link.connection.refresh_resource_filter_model()
         filter_model = self._link.connection.resource_filter_model
         filter_model.set_online(url, "tool_filter", {1: True})
-        self.assertEqual(self._link.connection.disabled_filter_names(url, "tool_filter"), set())
+        self.assertEqual(self._link.connection.online_filters(url, "tool_filter"), {"tool": True})
 
 
 if __name__ == "__main__":

--- a/tests/test_spine_db_fetcher.py
+++ b/tests/test_spine_db_fetcher.py
@@ -67,18 +67,10 @@ class TestSpineDBFetcher(unittest.TestCase):
         if self._db_mngr.can_fetch_more(self._db_map, fetcher):
             self._db_mngr.fetch_more(self._db_map, fetcher)
         fetcher.handle_items_added.assert_any_call(
-            {
-                self._db_map: [
-                    {'id': 1, 'name': 'Base', 'description': 'Base alternative', 'commit_id': 1},
-                ]
-            }
+            {self._db_map: [{'id': 1, 'name': 'Base', 'description': 'Base alternative', 'commit_id': 1}]}
         )
         fetcher.handle_items_added.assert_any_call(
-            {
-                self._db_map: [
-                    {'id': 2, 'name': 'alt', 'description': None, 'commit_id': 2},
-                ]
-            }
+            {self._db_map: [{'id': 2, 'name': 'alt', 'description': None, 'commit_id': 2}]}
         )
         self.assertEqual(
             self._db_mngr.get_item(self._db_map, "alternative", 2),


### PR DESCRIPTION
User can now change if new scenario/tool filters are online by default using the Link properties tab.

Related PR: Spine-project/spine-engine#73

Resolves #1914

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- ~[ ] Unit tests pass~ Unit tests were run manually on local machine as there were changes in spine-engine as well
