### PR TITLE
Fix removing items from stacked tables in DB editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -204,17 +204,16 @@ class StackedTableView(AutoFilterCopyPasteTableView):
     def remove_selected(self):
         """Removes selected indexes."""
         selection = self.selectionModel().selection()
-        row_counts = []
+        rows = []
         while not selection.isEmpty():
             current = selection.takeAt(0)
             top = current.top()
             bottom = current.bottom()
-            row_counts.append((top, bottom - top + 1))
+            rows += range(top, bottom + 1)
         # Get data grouped by db_map
         self.selectionModel().clearSelection()
         model = self.model()
-        for row, count in row_counts:
-            model.removeRows(row, count)
+        model.remove_rows(rows)
 
     @Slot(QModelIndex, QModelIndex)
     def _refresh_copy_paste_actions(self, _, __):


### PR DESCRIPTION
Removing items from stacked tables in Database Editor now correctly deletes the data from the database.

Fixes #3128

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
