### PR TITLE
Fix pasting parameter type data to Parameter definition tables

### DIFF
--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -62,19 +62,19 @@ def optional_to_string(x: Optional[Any]) -> Optional[str]:
     return str(x) if x is not None else None
 
 
-def group_to_string(types: Union[str, tuple[str, ...]]) -> Optional[str]:
-    if not types:
+def group_to_string(group: Union[str, tuple[str, ...]]) -> Optional[str]:
+    if not group:
         return None
-    if isinstance(types, str):
-        return types
-    return DB_ITEM_SEPARATOR.join(types)
+    if isinstance(group, str):
+        return group
+    return DB_ITEM_SEPARATOR.join(group)
 
 
-def string_to_group(types: Optional[str]) -> Union[str, tuple[str, ...]]:
-    if not types:
+def string_to_group(string: Optional[str]) -> Union[str, tuple[str, ...]]:
+    if not string:
         return ()
-    separator = DB_ITEM_SEPARATOR if DB_ITEM_SEPARATOR in types else ","
-    return tuple(stripped for t in types.split(separator) if (stripped := t.strip()))
+    separator = DB_ITEM_SEPARATOR if DB_ITEM_SEPARATOR in string else ","
+    return tuple(stripped for t in string.split(separator) if (stripped := t.strip()))
 
 
 def parameter_value_to_string(value: Any) -> str:

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -423,14 +423,6 @@ class EntityMixin:
                     new_to_be_added.setdefault(db_map, []).append(item)
         return new_to_be_added
 
-    def _make_item(self, row):
-        item = super()._make_item(row)
-        byname = item["entity_byname"]
-        if not isinstance(byname, tuple):
-            byname = tuple(byname.split(DB_ITEM_SEPARATOR)) if byname else ()
-        item["entity_byname"] = byname
-        return item
-
     @classmethod
     def _entity_class_name_candidates_by_entity(cls, db_map: DatabaseMapping, row_data: list) -> list[str]:
         byname = row_data[cls.entity_byname_column]

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -114,6 +114,13 @@ class StackedTableView(AutoFilterCopyPasteTableView):
             return group_to_string(value)
         return super()._convert_copied(row, column, value, model)
 
+    def _convert_pasted(
+        self, row: int, column: int, str_value: Optional[str], model: Union[SingleModelBase, EmptyModelBase]
+    ) -> Any:
+        if model.header[column] in model.group_fields:
+            return string_to_group(str_value)
+        return super()._convert_pasted(row, column, str_value, model)
+
     def _make_delegate(self, column_name, delegate_class):
         """Creates a delegate for the given column and returns it.
 
@@ -255,16 +262,12 @@ class ParameterTableView(StackedTableView):
         header = model.header[column]
         if header == self.value_column_header:
             return parameter_value_to_string(value)
-        if header == "entity_byname":
-            return group_to_string(value)
         return super()._convert_copied(row, column, value, model)
 
     def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
         header = model.header[column]
         if header == self.value_column_header:
             return string_to_parameter_value(str_value)
-        if header == "entity_byname":
-            return string_to_group(str_value)
         return super()._convert_pasted(row, column, str_value, model)
 
     def populate_context_menu(self):
@@ -473,16 +476,12 @@ class EntityAlternativeTableViewBase(StackedTableView):
 
     def _convert_copied(self, row: int, column: int, value: Any, model: MinimalTableModel) -> Optional[str]:
         header = model.header[column]
-        if header == "entity_byname":
-            return group_to_string(value)
         if header == "active":
             return bool_to_string(value) if value is not None else None
         return super()._convert_copied(row, column, value, model)
 
     def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
         header = model.header[column]
-        if header == "entity_byname":
-            return string_to_group(str_value)
         if header == "active":
             return string_to_bool(str_value)
         return super()._convert_pasted(row, column, str_value, model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,8 @@ def db_mngr(application, app_settings, logger):
 
 
 @pytest.fixture
-def db_map(db_mngr, logger):
+def db_map(db_mngr, logger, request):
     db_map = db_mngr.get_db_map("sqlite://", logger, create=True)
-    db_mngr.name_registry.register(db_map.sa_url, "mock_db")
+    db_name = "mock_db" if request.cls is None else request.cls.__name__ + "_db"
+    db_mngr.name_registry.register(db_map.sa_url, db_name)
     return db_map

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -372,6 +372,20 @@ def assert_table_model_data(
                 test_case.assertEqual(model.index(row, column).data(role), expected[row][column])
 
 
+def assert_table_model_data_pytest(
+    model: QAbstractTableModel,
+    expected: list[list[Any]],
+    role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
+) -> None:
+    assert model.rowCount() == len(expected)
+    for row in range(model.rowCount()):
+        assert model.columnCount() == len(expected[row])
+        for column in range(model.columnCount()):
+            data = model.index(row, column).data(role)
+            expected_data = expected[row][column]
+            assert data == expected_data, f"{data} != {expected_data} on row {row} column {column}"
+
+
 def fetch_model(model):
     while model.canFetchMore(QModelIndex()):
         model.fetchMore(QModelIndex())

--- a/tests/spine_db_editor/conftest.py
+++ b/tests/spine_db_editor/conftest.py
@@ -1,0 +1,34 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from unittest import mock
+from PySide6.QtWidgets import QApplication
+import pytest
+from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
+
+
+@pytest.fixture
+def db_editor(db_mngr, db_map, logger):
+    with (
+        mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"),
+        mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.show"),
+    ):
+        mock_settings = mock.MagicMock()
+        mock_settings.value.side_effect = lambda *args, **kwargs: 0
+        db_editor = SpineDBEditor(db_mngr, [db_map.db_url])
+    QApplication.processEvents()
+    yield db_editor
+    with (
+        mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.save_window_state"),
+        mock.patch("spinetoolbox.spine_db_manager.QMessageBox"),
+    ):
+        db_editor.close()
+    db_editor.deleteLater()

--- a/tests/spine_db_editor/test_stacked_table_seam.py
+++ b/tests/spine_db_editor/test_stacked_table_seam.py
@@ -25,21 +25,14 @@ class Bottomtable(BelowSeam, QTableView):
     pass
 
 
-@pytest.fixture
-def parent(application):
-    parent_widget = QWidget()
-    yield parent_widget
-    parent_widget.deleteLater()
-
-
 class TestStackedTableSeam:
-    def test_navigating_from_top_to_bottom_and_back(self, parent):
-        top_table = TopTable(parent)
-        top_model = QStandardItemModel(parent)
+    def test_navigating_from_top_to_bottom_and_back(self, parent_widget):
+        top_table = TopTable(parent_widget)
+        top_model = QStandardItemModel(parent_widget)
         top_model.appendRow([QStandardItem("top A"), QStandardItem("top B")])
         top_table.setModel(top_model)
-        bottom_table = Bottomtable(parent)
-        bottom_model = QStandardItemModel(parent)
+        bottom_table = Bottomtable(parent_widget)
+        bottom_model = QStandardItemModel(parent_widget)
         bottom_model.appendRow([QStandardItem("bottom A"), QStandardItem("bottom B")])
         bottom_table.setModel(bottom_model)
         seam = StackedTableSeam(top_table, bottom_table)

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -22,7 +22,12 @@ from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, Qt
 from PySide6.QtWidgets import QApplication, QMessageBox
 from spinedb_api import Array, DatabaseMapping, import_functions
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
-from tests.mock_helpers import assert_table_model_data, fetch_model, mock_clipboard_patch
+from tests.mock_helpers import (
+    assert_table_model_data,
+    assert_table_model_data_pytest,
+    fetch_model,
+    mock_clipboard_patch,
+)
 from tests.spine_db_editor.helpers import TestBase
 from tests.spine_db_editor.widgets.helpers import EditorDelegateMocking, add_entity, add_zero_dimension_entity_class
 
@@ -587,6 +592,22 @@ class TestEntityAlternativeTableView(TestBase):
         self.assertTrue(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
         self._db_editor.ui.tableView_parameter_definition.set_db_column_visibility(True)
         self.assertFalse(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
+
+
+class TestEmptyParameterDefinitionTableView:
+    def test_paste_parameter_types(self, db_editor):
+        table_view = db_editor.ui.empty_parameter_definition_table_view
+        model = table_view.model()
+        type_column = model.header.index("valid types")
+        index = model.index(0, type_column)
+        table_view.setCurrentIndex(index)
+        with mock_clipboard_patch("bool", "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
+            assert table_view.paste()
+        expected = [
+            [None, None, "bool", None, None, None, "TestEmptyParameterDefinitionTableView_db"],
+            [None, None, None, None, None, None, "TestEmptyParameterDefinitionTableView_db"],
+        ]
+        assert_table_model_data_pytest(model, expected)
 
 
 class TestEmptyParameterValueTableView(TestBase):


### PR DESCRIPTION
This PR fixes a bug where pasting to `valid types` column in Parameter definition table in DB editor would scramble the column data.

Fixes #3145

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
