### PR TITLE
Fix opening value editor on empty rows

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1401,20 +1401,33 @@ DB_ITEM_SEPARATOR = " \u01C0 "
 """Display string to separate items such as entity names."""
 
 
-def parameter_identifier(database, parameter, names, alternative):
+def parameter_identifier(
+    database: str | None,
+    entity_class_name: str | None,
+    entity_byname: list[str] | None,
+    parameter: str,
+    alternative: str | None,
+) -> str:
     """Concatenates given information into parameter value identifier string.
 
     Args:
-        database (str, optional): database's code name
-        parameter (str): parameter's name
-        names (list of str): name of the entity or class that holds the value
-        alternative (str or NoneType): name of the value's alternative
+        database: database's code name
+        entity_class_name: entity class' name
+        entity_byname: entity's byname
+        parameter: parameter's name
+        alternative: name of the value's alternative
+
+    Returns:
+        identifier string
     """
     parts = [database] if database is not None else []
-    parts += [parameter]
+    if entity_class_name is not None:
+        parts.append(entity_class_name)
+    if entity_byname is not None:
+        parts += [DB_ITEM_SEPARATOR.join(entity_byname)]
+    parts.append(parameter)
     if alternative is not None:
         parts += [alternative]
-    parts += [DB_ITEM_SEPARATOR.join(names)]
     return " - ".join(parts)
 
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -656,19 +656,20 @@ class EditParameterValueMixin:
         if item is None:
             return ""
         database = self.index(index.row(), self.columnCount() - 1).data()
+        entity_class_name = item["entity_class_name"]
         if self.item_type == "parameter_definition":
             parameter_name = item["name"]
-            names = [item["entity_class_name"]]
+            entity_byame = None
             alternative_name = None
         elif self.item_type == "parameter_value":
             parameter_name = item["parameter_name"]
-            names = list(item["entity_byname"])
+            entity_byame = list(item["entity_byname"])
             alternative_name = item["alternative_name"]
         else:
             raise ValueError(
                 f"invalid item_type: expected parameter_definition or parameter_value, got {self.item_type}"
             )
-        return parameter_identifier(database, parameter_name, names, alternative_name)
+        return parameter_identifier(database, entity_class_name, entity_byame, parameter_name, alternative_name)
 
     def get_set_data_delayed(self, index):
         """Returns a function that ParameterValueEditor can call to set data for the given index at any later time,

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -1192,20 +1192,15 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
         alternative_name = self.db_mngr.get_item(db_map, "alternative", alternative_id).get("name", "")
         return entity_names, parameter_name, alternative_name, self.db_mngr.name_registry.display_name(db_map.sa_url)
 
-    def index_name(self, index):
+    def index_name(self, index: QModelIndex) -> str:
         """Returns a string that concatenates the object and parameter names corresponding to the given data index.
+
         Used by plotting and ParameterValueEditor.
-
-        Args:
-            index (QModelIndex)
-
-        Returns:
-            str
         """
         if not self.index_in_data(index):
             return ""
         entity_names, parameter_name, alternative_name, db_name = self.all_header_names(index)
-        return parameter_identifier(db_name, parameter_name, entity_names, alternative_name)
+        return parameter_identifier(db_name, None, parameter_name, entity_names, alternative_name)
 
     def column_name(self, column):
         """Returns a string that concatenates the object and parameter names corresponding to the given column.

--- a/tests/spine_db_editor/mvcmodels/test_compound_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_compound_models.py
@@ -91,7 +91,7 @@ class TestCompoundParameterDefinitionModel(TestBase):
         model.init_model()
         fetch_model(model)
         index = model.index(0, 3)
-        self.assertEqual(model.index_name(index), "TestCompoundParameterDefinitionModel_db - x - Object")
+        self.assertEqual(model.index_name(index), "TestCompoundParameterDefinitionModel_db - Object - x")
 
 
 class TestCompoundParameterValueModel(TestBase):
@@ -190,7 +190,9 @@ class TestCompoundParameterValueModel(TestBase):
         model.init_model()
         fetch_model(model)
         index = model.index(0, 3)
-        self.assertEqual(model.index_name(index), "TestCompoundParameterValueModel_db - x - Base - mysterious cube")
+        self.assertEqual(
+            model.index_name(index), "TestCompoundParameterValueModel_db - Object - mysterious cube - x - Base"
+        )
 
     def test_removing_first_of_two_rows(self):
         self._db_map.add_entity_class(name="Object")

--- a/tests/spine_db_editor/mvcmodels/test_empty_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_empty_models.py
@@ -322,7 +322,7 @@ class TestEmptyParameterDefinitionModel:
         with q_object(EmptyParameterDefinitionModel(db_mngr, parent=None)) as model:
             model.append_empty_row()
             index = model.index(0, model.columnCount() - 2)
-            assert model.index_name(index) == "<database> - <entity_class_name> - <parameter_name>"
+            assert model.index_name(index) == "<database> - <entity_class> - <parameter>"
 
     def test_value_index_name_when_row_has_data(self, db_mngr):
         with q_object(EmptyParameterDefinitionModel(db_mngr, parent=None)) as model:
@@ -341,10 +341,7 @@ class TestEmptyParameterValueModel:
         with q_object(EmptyParameterValueModel(db_mngr, parent=None)) as model:
             model.append_empty_row()
             index = model.index(0, model.columnCount() - 2)
-            assert (
-                model.index_name(index)
-                == "<database> - <entity_class_name> - <entity_byname> - <parameter_name> - <alternative_name>"
-            )
+            assert model.index_name(index) == "<database> - <entity_class> - <entity> - <parameter> - <alternative>"
 
     def test_value_index_name_when_row_has_data(self, db_mngr):
         with q_object(EmptyParameterValueModel(db_mngr, parent=None)) as model:
@@ -352,11 +349,7 @@ class TestEmptyParameterValueModel:
             model.set_undo_stack(undo_stack)
             model.append_empty_row()
             indexes = [model.index(0, 0), model.index(0, 1), model.index(0, 2), model.index(0, 3), model.index(0, 5)]
-            data = ["my class", "my entity", "my parameter", "my alternative", "my database"]
+            data = ["my class", ("my entity",), "my parameter", "my alternative", "my database"]
             model.batch_set_data(indexes, data)
             index = model.index(0, model.columnCount() - 2)
             assert model.index_name(index) == "my database - my class - my entity - my parameter - my alternative"
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import QLineEdit, QWidget
 from spine_engine.load_project_items import load_item_specification_factories
 from spinetoolbox.config import PROJECT_FILENAME, PROJECT_LOCAL_DATA_DIR_NAME, PROJECT_LOCAL_DATA_FILENAME
 from spinetoolbox.helpers import (
+    DB_ITEM_SEPARATOR,
     HTMLTagFilter,
     add_keyboard_shortcut_to_tool_tip,
     add_keyboard_shortcuts_to_action_tool_tips,
@@ -48,6 +49,7 @@ from spinetoolbox.helpers import (
     merge_dicts,
     normcase_database_url_path,
     order_key,
+    parameter_identifier,
     plain_to_rich,
     plain_to_tool_tip,
     recursive_overwrite,
@@ -582,3 +584,15 @@ class TestNormcaseDatabaseUrlPath:
             assert (
                 normcase_database_url_path("sqlite:///home/SansSerif/in.sqlite") == "sqlite:///home/SansSerif/in.sqlite"
             )
+
+
+class TestParameterIdentifier:
+    def test_correctness(self):
+        parts = DB_ITEM_SEPARATOR.join(("a", "b"))
+        assert (
+            parameter_identifier("db", "my class", ["a", "b"], "par", "alt") == f"db - my class - {parts} - par - alt"
+        )
+        assert parameter_identifier(None, "my class", ["a", "b"], "par", "alt") == f"my class - {parts} - par - alt"
+        assert parameter_identifier("db", None, ["a"], "par", "alt") == f"db - a - par - alt"
+        assert parameter_identifier("db", "my class", None, "par", "alt") == f"db - my class - par - alt"
+        assert parameter_identifier("db", "my class", ["a", "b"], "par", None) == f"db - my class - {parts} - par"


### PR DESCRIPTION
This PR fixes a bug that prevented the opening of Value editor from empty rows in DB editor.

Fixes # 3167

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
