### PR TITLE
Update ZIP bundle workflow to make a release

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -104,7 +104,7 @@ jobs:
           body: |
             See [CHANGELOG.md](https://github.com/spine-tools/Spine-Toolbox/blob/${{ inputs.git-ref }}/CHANGELOG.md) for release notes.
           files: |
-            dist/Spine Toolbox/*.zip
+            dist/Spine Toolbox/Spine-Toolbox-win-${{ inputs.git-ref }}.zip
       - name: Upload archive
         if: steps.commit.outputs.is_tag == 'false'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- **workflows: upgrade actions/checkout**
- **workflows/make_bundle: test if git-ref is a tag**
- **workflows/make_bundle: get python full version in an output**
- **workflows/make_bundle: if tag, install from PyPI, else from source**
- **workflows/make_bundle: use python full version in embedded url**
- **workflows/make_bundle: create release / upload bundle as artifact**

This updates the workflow such that when git-ref is a tag, it creates
a GH release, and adds the ZIP bundle as an asset.

## Review notes

- Please check if the path in `files:` in the "Create GitHub release"
  step is correct ([docs](https://github.com/softprops/action-gh-release?tab=readme-ov-file#-customizing)).
- I removed `dev-requirements.txt` from "Install Toolbox from repo"
- The ZIP bundle for the release version is created from the PyPI
  wheel for consistency (otherwise dependencies won't match).

## `spine-conductor` integration

Add a section like this to the config:

```toml
[tool.conductor.bundle]
repo = "spine-tools/Spine-Toolbox"
file = "make_bundle.yml"
```

Then you can trigger like this: `conduct bundle --pkgtags pkgtags.json --name Spine-Toolbox -c release.toml`

The `--name` flag is optional, as it defaults to `Spine-Toolbox`. 

## Checklist before merging
- [ ] ~Documentation is up-to-date~
- [ ] ~Release notes have been updated~
- [ ] ~Unit tests have been added/updated accordingly~
- [ ] ~Code has been formatted by black & isort~
- [ ] ~Unit tests pass~
