### PR TITLE
Fix remote database URL stringification

### DIFF
--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -343,7 +343,7 @@ class SpineDBManager(QObject):
 
     def get_db_map(
         self,
-        url: str,
+        url: str | URL,
         logger: LoggerInterface,
         create: bool = False,
         force_upgrade_prompt: bool = False,
@@ -352,7 +352,8 @@ class SpineDBManager(QObject):
         """Returns a DatabaseMapping instance from url if possible, None otherwise.
         If needed, asks the user to upgrade to the latest db version.
         """
-        url = str(url)
+        if isinstance(url, URL):
+            url = url.render_as_string(hide_password=False)
         db_map = self._db_maps.get(url)
         if db_map is not None:
             return db_map


### PR DESCRIPTION
Calling `str()` on SQLAlchemy URL will hide the password which is desirable for display purposes but doesn't work if the URL is used to connect to a remote database.

Re spine-tools/Spine-Database-API#586

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
