### PR TITLE
Fix calculation of large directory sizes

### DIFF
--- a/spinetoolbox/file_size_aggregator.py
+++ b/spinetoolbox/file_size_aggregator.py
@@ -18,7 +18,7 @@ from PySide6.QtCore import QObject, QTimer, Signal
 
 
 class AggregatorProcess(QObject):
-    aggregated = Signal(int)
+    aggregated = Signal(str)  # Send size as a string; int is only 32 bits, too small for large directories.
 
     def __init__(self, parent: Optional[QObject]):
         super().__init__(parent)
@@ -41,7 +41,7 @@ class AggregatorProcess(QObject):
             size = self._receiver.recv()
             self._process.join()
             self._process = None
-            self.aggregated.emit(size)
+            self.aggregated.emit(str(size))
         else:
             self._timer.start()
 

--- a/spinetoolbox/widgets/project_settings_dialog.py
+++ b/spinetoolbox/widgets/project_settings_dialog.py
@@ -57,8 +57,10 @@ class ProjectSettingsDialog(QDialog):
         self._ui.item_directory_size_label.setText(f"Calculating...")
         self._file_size_aggregator.start_aggregating(self._temp_item_paths)
 
-    @Slot(int)
-    def _update_path_sizes(self, size: int) -> None:
+    @Slot(str)
+    def _update_path_sizes(self, size: int | str) -> None:
+        if isinstance(size, str):
+            size = int(size)
         number, unit = display_byte_size(size)
         self._ui.item_directory_size_label.setText(f"Temporary files in item directories: {number}{unit}")
 

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -1053,8 +1053,10 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         else:
             self.ui.work_dir_info_label.setText("Cannot find work directory.")
 
-    @Slot(int)
-    def set_work_directory_size(self, size: int) -> None:
+    @Slot(str)
+    def set_work_directory_size(self, size: int | str) -> None:
+        if isinstance(size, str):
+            size = int(size)
         rounded_size, unit = display_byte_size(size)
         self.ui.work_dir_info_label.setText(f"Work directory size: {rounded_size}{unit}")
 

--- a/tests/test_file_size_aggregator.py
+++ b/tests/test_file_size_aggregator.py
@@ -22,7 +22,7 @@ class TestAggregatorProcess:
             with signal_waiter(aggregator.aggregated, timeout=1.0) as waiter:
                 aggregator.start_aggregating([tmp_path])
                 waiter.wait()
-                assert waiter.args == (5,)
+                assert waiter.args == ("5",)
             aggregator.tear_down()
 
 


### PR DESCRIPTION
This fixes a bug in directory size aggregator where directory sizes larger than a 32bit int could not be displayed.

Fixes #3188
## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
