### PR TITLE
FetchIndex can't be class attributes

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -99,7 +99,10 @@ class EntityClassItem(MultiDBTreeItem):
 
     visual_key = ["name", "dimension_name_list", "superclass_name"]
     item_type = "entity_class"
-    _fetch_index = EntityClassIndex()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fetch_index = EntityClassIndex()
 
     @property
     def display_icon(self):
@@ -179,13 +182,13 @@ class EntityItem(MultiDBTreeItem):
 
     visual_key = ["entity_class_name", "entity_byname"]
     item_type = "entity"
-    _fetch_index = EntityIndex()
-    _entity_group_index = EntityGroupIndex()
 
     def __init__(self, *args, is_member=False, **kwargs):
         super().__init__(*args, **kwargs)
         self._is_group = False
         self._is_member = is_member
+        self._fetch_index = EntityIndex()
+        self._entity_group_index = EntityGroupIndex()
         self._entity_group_fetch_parent = FlexibleFetchParent(
             "entity_group",
             accepts_item=self._accepts_entity_group_item,

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -37,6 +37,7 @@ class MultiDBTreeItem(TreeItem):
             db_map_ids = {}
         self._db_map_ids = db_map_ids
         self._child_map = {}  # Maps db_map to id to row number
+        self._fetch_index = None
         self._fetch_parent = FlexibleFetchParent(
             self.fetch_item_type,
             accepts_item=self.accepts_item,


### PR DESCRIPTION
They need to be instance attributes of course, so refresh works.

Fixes #3196 3196

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
