### PR TITLE
Fix Traceback when copying empty rows from Parameter definition and value tables

### DIFF
--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -78,6 +78,8 @@ def string_to_group(string: Optional[str]) -> Union[str, tuple[str, ...]]:
 
 
 def parameter_value_to_string(value: Any) -> str:
+    if value is None:
+        return ""
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, int):

--- a/tests/spine_db_editor/test_helpers.py
+++ b/tests/spine_db_editor/test_helpers.py
@@ -74,6 +74,7 @@ class TestStringToGroup(unittest.TestCase):
 
 class TestParameterValueToString(unittest.TestCase):
     def test_non_numeric_values(self):
+        self.assertEqual(parameter_value_to_string(None), "")
         self.assertEqual(parameter_value_to_string("is_string"), "is_string")
         self.assertEqual(parameter_value_to_string(True), "true")
         self.assertEqual(parameter_value_to_string(False), "false")


### PR DESCRIPTION
Copying would cause a Traceback if default_value or value column was empty.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
