### PR TITLE
Fix Toolbox with PySide6 6.10

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -607,6 +607,9 @@ class ColoredIconEngine(QIconEngine):
             self._icon.actualSize(size), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation
         )
 
+    def paint(self, painter, rect, mode=None, state=None):
+        pass
+
 
 def color_pixmap(pixmap: QPixmap, color: QColor) -> QPixmap:
     img = pixmap.toImage()

--- a/spinetoolbox/widgets/project_item_drag.py
+++ b/spinetoolbox/widgets/project_item_drag.py
@@ -223,3 +223,6 @@ class _ChoppedIconEngine(QIconEngine):
 
     def pixmap(self, size, mode, state):
         return self._pixmap
+
+    def paint(self, painter, rect, mode=None, state=None):
+        pass


### PR DESCRIPTION
This PR fixes the crashes caused by PySide6 6.10.

Fixes #3200

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
