### PR TITLE
Fix Shiboken warnings in unit tests

### DIFF
--- a/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
+++ b/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
@@ -136,7 +136,7 @@ class SimpleFilterCheckboxListModel(QAbstractListModel):
                         self._selected.add(item)
             self._all_selected = self._check_all_selected()
             self.dataChanged.emit(index, index, [Qt.ItemDataRole.CheckStateRole])
-            self.dataChanged.emit(0, 0, [Qt.ItemDataRole.CheckStateRole])
+            self.dataChanged.emit(self.index(0, 0), self.index(0, 0), [Qt.ItemDataRole.CheckStateRole])
 
     def set_list(self, data, all_selected=True):
         self.beginResetModel()

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -90,21 +90,21 @@ class SpineDBManager(QObject):
 
     error_msg = Signal(object)
     # Data changed signals
-    items_added = Signal(str, dict)
+    items_added = Signal(str, object)
     """Emitted whenever items are added to a DB.
 
     Args:
         str: item type, such as "object_class"
         dict: mapping DatabaseMapping to list of added dict-items.
     """
-    items_updated = Signal(str, dict)
+    items_updated = Signal(str, object)
     """Emitted whenever items are updated in a DB.
 
     Args:
         str: item type, such as "object_class"
         dict: mapping DatabaseMapping to list of updated dict-items.
     """
-    items_removed = Signal(str, dict)
+    items_removed = Signal(str, object)
     """Emitted whenever items are removed from a DB.
 
     Args:


### PR DESCRIPTION
One of the warnings was probably a minor visual bug in check box lists.

No associated issue

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
