### PR TITLE
Fix zip bundle when bundling a tagged release

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -99,6 +99,10 @@ jobs:
         shell: bash
         run: |
           python -c "from importlib.metadata import version; print('version=' + version('spinetoolbox'))" >> $GITHUB_OUTPUT
+      - name: Zip bundle
+        if: steps.commit.outputs.is_tag == 'true'
+        run: |
+          python -c "import shutil; shutil.make_archive('Spine-Toolbox-win-${{ steps.toolbox-version.outputs.version }}','zip', 'dist/Spine Toolbox')"
       - name: Create GitHub release for version ${{ inputs.git-ref }}
         if: steps.commit.outputs.is_tag == 'true'
         uses: softprops/action-gh-release@v2
@@ -107,7 +111,7 @@ jobs:
           body: |
             See [CHANGELOG.md](https://github.com/spine-tools/Spine-Toolbox/blob/${{ inputs.git-ref }}/CHANGELOG.md) for release notes.
           files: |
-            dist/Spine Toolbox/Spine-Toolbox-win-${{ inputs.git-ref }}.zip
+            Spine-Toolbox-win-${{ inputs.git-ref }}.zip
       - name: Upload archive
         if: steps.commit.outputs.is_tag == 'false'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Zip the files before we try to upload the zip.

No associated issue

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
