### PR TITLE
Fix broken coordinate input in Entity table

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
@@ -12,8 +12,9 @@
 
 """Custom item delegates."""
 from numbers import Number
-from PySide6.QtCore import QEvent, QModelIndex, QObject, QRect, QSize, Qt, Signal
-from PySide6.QtGui import QColor, QDoubleValidator, QFont, QFontMetrics, QIcon
+import re
+from PySide6.QtCore import QEvent, QModelIndex, QRect, QSize, Qt, Signal
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QIcon, QRegularExpressionValidator
 from PySide6.QtWidgets import QStyledItemDelegate
 from spinedb_api import to_database
 from spinedb_api.parameter_value import join_value_and_type
@@ -673,16 +674,22 @@ class PlainTextDelegate(TableDelegate):
 class PlainNumberDelegate(TableDelegate):
     """A delegate for non-localized numeric columns."""
 
+    _NUMBER_REGEXP = "^[+-]?[0-9]*($|\.[0-9]*$)"
+
     def setModelData(self, editor, model, index):
         """Send signal."""
-        self.data_committed.emit(index, float(editor.data()))
+        text = editor.data()
+        data = float(text) if text else None
+        self.data_committed.emit(index, data)
 
     def setEditorData(self, editor, index):
-        editor.setText(str(index.data(Qt.ItemDataRole.DisplayRole)))
+        data = index.data(Qt.ItemDataRole.DisplayRole)
+        text = str(data) if data is not None else ""
+        editor.setText(text)
 
     def createEditor(self, parent, option, index):
         editor = CustomLineEditor(parent)
-        editor.setValidator(QDoubleValidator(editor))
+        editor.setValidator(QRegularExpressionValidator(self._NUMBER_REGEXP, editor))
         return editor
 
 

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -318,8 +318,7 @@ class GraphViewMixin:
         for item in self.ui.graphicsView.items():
             if isinstance(item, EntityItem) and not updated_ids.isdisjoint(item.db_map_ids):
                 entity = entities_by_db_map_id[next(iter(item.db_map_ids))]
-                if (latitude := entity["lat"]) is not None:
-                    longitude = entity["lon"]
+                if (latitude := entity["lat"]) is not None and (longitude := entity["lon"]) is not None:
                     x, y = self.ui.graphicsView.x_y(latitude, longitude)
                     position = item.pos()
                     if not math.isclose(position.x(), x, rel_tol=1e-10) or not math.isclose(


### PR DESCRIPTION
The latitude, longitude and altitude fields now accept non-localized numbers properly and handle Nones gracefully.

Fixes #3207

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
