### PR TITLE
Add execution test

### DIFF
--- a/execution_tests/remove_db_items_from_upstream_tool/.gitignore
+++ b/execution_tests/remove_db_items_from_upstream_tool/.gitignore
@@ -1,0 +1,3 @@
+.sqlite-journal
+.spinetoolbox/local/
+*.bak*

--- a/execution_tests/remove_db_items_from_upstream_tool/.spinetoolbox/project.json
+++ b/execution_tests/remove_db_items_from_upstream_tool/.spinetoolbox/project.json
@@ -1,0 +1,123 @@
+{
+    "project": {
+        "version": 13,
+        "description": "",
+        "settings": {
+            "enable_execute_all": true,
+            "store_external_paths_as_relative": false
+        },
+        "specifications": {
+            "Tool": [
+                {
+                    "type": "path",
+                    "relative": true,
+                    "path": ".spinetoolbox/specifications/Tool/remove_entities.json"
+                },
+                {
+                    "type": "path",
+                    "relative": true,
+                    "path": ".spinetoolbox/specifications/Tool/assert_data.json"
+                }
+            ]
+        },
+        "connections": [
+            {
+                "name": "from Remove entities to Data Store",
+                "from": [
+                    "Remove entities",
+                    "right"
+                ],
+                "to": [
+                    "Data Store",
+                    "left"
+                ],
+                "filter_settings": {
+                    "known_filters": {},
+                    "auto_online": true,
+                    "enabled_filter_types": {
+                        "alternative_filter": false,
+                        "scenario_filter": true
+                    }
+                }
+            },
+            {
+                "name": "from Data Store to Assert no orphan data",
+                "from": [
+                    "Data Store",
+                    "right"
+                ],
+                "to": [
+                    "Assert no orphan data",
+                    "left"
+                ],
+                "filter_settings": {
+                    "known_filters": {
+                        "db_url@Data Store": {
+                            "scenario_filter": {},
+                            "alternative_filter": {
+                                "Base": true
+                            }
+                        }
+                    },
+                    "auto_online": true,
+                    "enabled_filter_types": {
+                        "alternative_filter": false,
+                        "scenario_filter": true
+                    }
+                }
+            }
+        ],
+        "jumps": []
+    },
+    "items": {
+        "Data Store": {
+            "type": "Data Store",
+            "description": "",
+            "x": -45.703125,
+            "y": 7.109375,
+            "url": {
+                "dialect": "sqlite",
+                "host": "",
+                "port": null,
+                "database": {
+                    "type": "path",
+                    "relative": true,
+                    "path": ".spinetoolbox/items/data_store/Data Store.sqlite"
+                },
+                "schema": ""
+            }
+        },
+        "Remove entities": {
+            "type": "Tool",
+            "description": "",
+            "x": -210.234375,
+            "y": 6.09375,
+            "specification": "Remove entities",
+            "execute_in_work": true,
+            "cmd_line_args": [
+                {
+                    "type": "resource",
+                    "arg": "db_url@Data Store"
+                }
+            ],
+            "kill_completed_processes": false,
+            "log_process_output": false
+        },
+        "Assert no orphan data": {
+            "type": "Tool",
+            "description": "",
+            "x": 101.5625,
+            "y": 10.15625,
+            "specification": "Assert data",
+            "execute_in_work": true,
+            "cmd_line_args": [
+                {
+                    "type": "resource",
+                    "arg": "db_url@Data Store"
+                }
+            ],
+            "kill_completed_processes": false,
+            "log_process_output": false
+        }
+    }
+}

--- a/execution_tests/remove_db_items_from_upstream_tool/.spinetoolbox/specifications/Tool/assert_data.json
+++ b/execution_tests/remove_db_items_from_upstream_tool/.spinetoolbox/specifications/Tool/assert_data.json
@@ -1,0 +1,13 @@
+{
+    "name": "Assert data",
+    "tooltype": "python",
+    "includes": [
+        "assert_data.py"
+    ],
+    "description": "Checks that a Spine database does not contain orphaned parameter value records.",
+    "inputfiles": [],
+    "inputfiles_opt": [],
+    "outputfiles": [],
+    "cmdline_args": [],
+    "includes_main_path": "../../.."
+}

--- a/execution_tests/remove_db_items_from_upstream_tool/.spinetoolbox/specifications/Tool/remove_entities.json
+++ b/execution_tests/remove_db_items_from_upstream_tool/.spinetoolbox/specifications/Tool/remove_entities.json
@@ -1,0 +1,13 @@
+{
+    "name": "Remove entities",
+    "tooltype": "python",
+    "includes": [
+        "remove_entities.py"
+    ],
+    "description": "Removes entities and entity references in cascade.",
+    "inputfiles": [],
+    "inputfiles_opt": [],
+    "outputfiles": [],
+    "cmdline_args": [],
+    "includes_main_path": "../../.."
+}

--- a/execution_tests/remove_db_items_from_upstream_tool/assert_data.py
+++ b/execution_tests/remove_db_items_from_upstream_tool/assert_data.py
@@ -1,0 +1,12 @@
+import sys
+from sqlalchemy import create_engine, text
+from spinedb_api import DatabaseMapping
+
+url = sys.argv[1]
+real_url = DatabaseMapping(url).db_url
+engine = create_engine(real_url)
+with engine.connect() as connection:
+    entity_ids = {row.id for row in connection.execute(text("select id from entity"))}
+    value_entity_ids = {row.entity_id for row in connection.execute(text("select entity_id from parameter_value"))}
+    print(value_entity_ids)
+    assert value_entity_ids.issubset(entity_ids)

--- a/execution_tests/remove_db_items_from_upstream_tool/execution_test.py
+++ b/execution_tests/remove_db_items_from_upstream_tool/execution_test.py
@@ -1,0 +1,33 @@
+import pathlib
+import subprocess
+import sys
+from spinedb_api import DatabaseMapping
+
+
+class TestRemovingDBItemsFromUpstreamTool:
+    _root_path = pathlib.Path(__file__).parent
+    _database_path = _root_path / ".spinetoolbox" / "items" / "data_store" / "Data Store.sqlite"
+
+    def _set_up(self):
+        self._database_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._database_path.exists():
+            self._database_path.unlink()
+        url = "sqlite:///" + str(self._database_path)
+        with DatabaseMapping(url, create=True) as db_map:
+            db_map.add_entity_class(name="Fish")
+            db_map.add_entity(entity_class_name="Fish", name="gold_fish")
+            db_map.add_parameter_definition(entity_class_name="Fish", name="buoyancy")
+            db_map.add_parameter_value(
+                entity_class_name="Fish",
+                entity_byname=("gold_fish",),
+                parameter_definition_name="buoyancy",
+                alternative_name="Base",
+                parsed_value=23.0,
+            )
+            db_map.commit_session("Add test data.")
+
+    def test_no_orphan_records_are_left_in_the_database(self):
+        self._set_up()
+        this_file = pathlib.Path(__file__)
+        completed = subprocess.run((sys.executable, "-m", "spinetoolbox", "--execute-only", str(this_file.parent)))
+        assert completed.returncode == 0

--- a/execution_tests/remove_db_items_from_upstream_tool/remove_entities.py
+++ b/execution_tests/remove_db_items_from_upstream_tool/remove_entities.py
@@ -1,0 +1,8 @@
+import sys
+from spinedb_api import DatabaseMapping
+
+url = sys.argv[1]
+with DatabaseMapping(url) as db_map:
+    for entity in db_map.find_entities():
+        entity.remove()
+    db_map.commit_session("Removed entities.")


### PR DESCRIPTION
This PR adds an execution test that tests a bug that corrupted databases when removing items from filtered databases. The bug has been fixed in spine-tools/Spine-Database-API#597

Re spine-tools/Spine-Database-API#594


## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
