### PR TITLE
Exclude PySide6 6.10.1 from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "PySide6 >= 6.9",
+    "PySide6 >= 6.9, !=6.10.1",
     "jupyter_client >=6.0",
     "qtconsole >=5.1",
     "spinedb_api>=0.36.2",

--- a/spinetoolbox/mvcmodels/empty_row_model.py
+++ b/spinetoolbox/mvcmodels/empty_row_model.py
@@ -58,7 +58,9 @@ class EmptyRowModel(MinimalTableModel):
         super().reset_model(main_data)
 
     @Slot(QModelIndex, QModelIndex, list)
-    def _handle_data_changed(self, top_left, bottom_right, roles=None):
+    def _handle_data_changed(
+        self, top_left: QModelIndex, bottom_right: QModelIndex, roles: list[Qt.ItemDataRole] | None = None
+    ) -> None:
         """Inserts a new last empty row in case the previous one has been filled
         with any data other than the defaults."""
         if roles and Qt.ItemDataRole.EditRole not in roles:

--- a/spinetoolbox/project_item/specification_editor_window.py
+++ b/spinetoolbox/project_item/specification_editor_window.py
@@ -285,6 +285,7 @@ class SpecificationEditorWindowBase(Generic[UI], QMainWindow):
     def _duplicate_kwargs(self) -> dict:
         return {}
 
+    @Slot()
     def _duplicate(self) -> None:
         if not self._toolbox.project():
             self.show_error("Please open or create a project first")

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -125,7 +125,7 @@ class GraphViewMixin:
         self._graph_fetch_more_later()
         self._entity_addition_mode: AddingObjects | ConnectingEntities | None = None
 
-    @Slot(int)
+    @Slot(object)
     def _update_time_line_index(self, index):
         for item in self.ui.graphicsView.entity_items:
             item.update_props(index)
@@ -162,6 +162,7 @@ class GraphViewMixin:
         self.db_mngr.items_added.connect(self._refresh_icons)
         self.db_mngr.items_updated.connect(self._refresh_icons)
 
+    @Slot(str, object)
     def _refresh_icons(self, item_type: str, db_map_data: DBMapPublicItems) -> None:
         """Runs when entity classes are added or updated in the db. Refreshes icons of entities in graph.
 

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -170,13 +170,15 @@ class StackedViewMixin:
             model.set_rows_to_default(model.rowCount() - 1)
 
     @Slot(QModelIndex, QModelIndex, list)
-    def _update_empty_rows(self, top_left, bottom_right, roles):
+    def _update_empty_rows(
+        self, top_left: QModelIndex, bottom_right: QModelIndex, roles: list[Qt.ItemDataRole]
+    ) -> None:
         """Updates empty default data on empty rows if relevant entity (class) name has changed.
 
         Args:
-            top_left (QModelIndex): top left corner of changed data in Entity tree
-            bottom_right (QModelIndex): bottom right corner of changed data in Entity tree
-            roles (list of Qt.ItemDataRole): affected item data roles
+            top_left: top left corner of changed data in Entity tree
+            bottom_right: bottom right corner of changed data in Entity tree
+            roles: affected item data roles
         """
         entity_selection_model = self.ui.treeView_entity.selectionModel()
         current_entity_index = entity_selection_model.currentIndex()

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -89,7 +89,9 @@ class TabularViewMixin:
             self._handle_entity_tree_selection_changed_in_pivot_table
         )
         self.ui.pivot_table.header_changed.connect(self._connect_pivot_table_header_signals)
-        self.ui.frozen_table.header_dropped.connect(self.handle_header_dropped)
+        self.ui.frozen_table.header_dropped.connect(
+            lambda dropped, catcher: self.handle_header_dropped(dropped, catcher)
+        )
         self.ui.frozen_table.selectionModel().currentChanged.connect(self._change_selected_frozen_row)
         self.frozen_table_model.rowsInserted.connect(self._check_frozen_value_selected)
         self.frozen_table_model.rowsRemoved.connect(self._check_frozen_value_selected)
@@ -140,7 +142,7 @@ class TabularViewMixin:
                         return True
         return False
 
-    @Slot(str, dict)
+    @Slot(str, object)
     def _reload_pivot_table_if_needed(self, item_type, db_map_data):
         if not self.pivot_table_model:
             return
@@ -508,7 +510,8 @@ class TabularViewMixin:
         )
         self.make_pivot_headers()
 
-    def _change_selected_frozen_row(self, current, previous):
+    @Slot(QModelIndex, QModelIndex)
+    def _change_selected_frozen_row(self, current: QModelIndex, previous: QModelIndex) -> None:
         """Sets the frozen value from selection in frozen table."""
         if not current.isValid():
             return

--- a/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
@@ -69,8 +69,10 @@ class TreeViewMixin:
         self.ui.scenario_tree_view.scenario_selection_changed.connect(
             self._handle_scenario_alternative_selection_changed
         )
-        self.entity_alternative_model.dataChanged.connect(self.build_graph)
-        self.parameter_value_model.dataChanged.connect(self._refresh_parameters_and_graph)
+        self.entity_alternative_model.dataChanged.connect(lambda top_left, bottom_right, roles: self.build_graph())
+        self.parameter_value_model.dataChanged.connect(
+            lambda top_left, bottom_right, roles: self._refresh_parameters_and_graph()
+        )
 
     def _refresh_parameters_and_graph(self):
         self._update_filter_parameter_value_ids()
@@ -98,7 +100,7 @@ class TreeViewMixin:
         self._update_filter_parameter_value_ids()
         self.build_graph()
 
-    @Slot(dict)
+    @Slot(object)
     def _handle_alternative_selection_changed(self, selected):
         self._filter_alternative_ids.clear()
         for db_map, alt_ids in selected.items():
@@ -110,7 +112,7 @@ class TreeViewMixin:
         self._update_filter_parameter_value_ids()
         self.build_graph()
 
-    @Slot(dict)
+    @Slot(object)
     def _handle_scenario_alternative_selection_changed(self, selected_ids):
         self._filter_scenario_ids = selected_ids
         # View specific stuff:

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -268,7 +268,7 @@ class ToolboxUI(QMainWindow):
         self.error_box.connect(self._show_error_box)
         # Menu commands
         self.ui.actionNew.triggered.connect(self.new_project)
-        self.ui.actionOpen.triggered.connect(self.open_project)
+        self.ui.actionOpen.triggered.connect(lambda _: self.open_project())
         self.ui.actionOpen_recent.setMenu(self.recent_projects_menu)
         self.ui.actionOpen_recent.hovered.connect(self.show_recent_projects_menu)
         self.ui.actionStart_jupyter_console.setMenu(self.kernels_menu)
@@ -278,7 +278,7 @@ class ToolboxUI(QMainWindow):
         self.ui.actionStart_default_julia_in_basic_console.triggered.connect(self.start_detached_julia_basic_console)
         self.ui.actionSave.triggered.connect(self.save_project)
         self.ui.actionSave_As.triggered.connect(self.save_project_as)
-        self.ui.actionClose.triggered.connect(lambda _checked=False: self.close_project())
+        self.ui.actionClose.triggered.connect(lambda _checked: self.close_project())
         self.ui.open_project_settings_action.triggered.connect(self.open_project_settings)
         self.ui.actionNew_DB_editor.triggered.connect(self.new_db_editor)
         self.ui.actionSettings.triggered.connect(self.show_settings)
@@ -503,7 +503,7 @@ class ToolboxUI(QMainWindow):
         self.open_project(project_dir, clear_event_log=False)
 
     @Slot()
-    def new_project(self):
+    def new_project(self) -> None:
         """Opens a file dialog where user can select a directory where a project is created.
         Pops up a question box if selected directory is not empty or if it already contains
         a Spine Toolbox project. Initial project name is the directory name.
@@ -565,18 +565,17 @@ class ToolboxUI(QMainWindow):
         self._plugin_manager.reload_plugins_with_local_data()
         self.msg.emit(f"New project <b>{self._project.name}</b> is now open")
 
-    @Slot()
-    def open_project(self, load_dir=None, clear_event_log=True):
+    def open_project(self, load_dir: str | None=None, clear_event_log: bool=True) -> bool:
         """Opens project from a selected or given directory.
 
         Args:
-            load_dir (str, optional): Path to project base directory. If default value is used,
+            load_dir: Path to project base directory. If default value is used,
                 a file explorer dialog is opened where the user can select the
                 project to open.
-            clear_event_log (bool): True clears the Event log before opening the project
+            clear_event_log: True clears the Event log before opening the project
 
         Returns:
-            bool: True when opening the project succeeded, False otherwise
+            True when opening the project succeeded, False otherwise
         """
         if not load_dir:
             custom_open_dialog = self.qsettings().value("appSettings/customOpenProjectDialog", defaultValue="true")
@@ -732,7 +731,7 @@ class ToolboxUI(QMainWindow):
         QApplication.restoreOverrideCursor()
 
     @Slot()
-    def save_project(self):
+    def save_project(self) -> None:
         """Saves project."""
         if not self._project:
             self.msg.emit("Please open or create a project first")
@@ -742,7 +741,7 @@ class ToolboxUI(QMainWindow):
         self.undo_stack.setClean()
 
     @Slot()
-    def save_project_as(self):
+    def save_project_as(self) -> None:
         """Asks user for a new project directory and duplicates the current project there.
         The name of the duplicated project will be the new directory name. The duplicated
         project is activated."""
@@ -805,8 +804,8 @@ class ToolboxUI(QMainWindow):
             self.ui.textBrowser_eventlog.clear()
         return True
 
-    @Slot(bool)
-    def open_project_settings(self, _=False):
+    @Slot()
+    def open_project_settings(self) -> None:
         """Opens a dialog where the user can manage current project's settings."""
         if not self._project:
             return
@@ -1328,8 +1327,8 @@ class ToolboxUI(QMainWindow):
                 f"10, go to Control Panel -> Default Programs to do this."
             )
 
-    @Slot(bool)
-    def new_db_editor(self):
+    @Slot()
+    def new_db_editor(self) -> None:
         editor = MultiSpineDBEditor(self.db_mngr, [])
         editor.show()
 
@@ -1411,6 +1410,7 @@ class ToolboxUI(QMainWindow):
         self.ui.menuEdit.insertAction(before, redo_action)
         self.ui.menuEdit.insertSeparator(before)
 
+    @Slot()
     def toggle_properties_tabbar_visibility(self):
         """Shows or hides the tab bar in properties dock widget. For debugging purposes."""
         if self.ui.tabWidget_item_properties.tabBar().isVisible():
@@ -1630,7 +1630,7 @@ class ToolboxUI(QMainWindow):
         return None
 
     @Slot()
-    def show_settings(self):
+    def show_settings(self) -> None:
         """Shows the Settings widget."""
         self.settings_form = SettingsWidget(self)
         self.settings_form.show()
@@ -2348,14 +2348,14 @@ class ToolboxUI(QMainWindow):
         return menu
 
     @Slot()
-    def start_detached_python_basic_console(self):
+    def start_detached_python_basic_console(self) -> None:
         """Starts basic console with the default Python interpreter."""
         python = resolve_python_interpreter(self.qsettings())
         _set_resource_limits(self.qsettings(), threading.Lock())
         self.start_detached_basic_console("python", python)
 
     @Slot()
-    def start_detached_julia_basic_console(self):
+    def start_detached_julia_basic_console(self) -> None:
         """Starts basic console with the default Julia executable."""
         julia = resolve_julia_executable(self.qsettings())
         project = resolve_julia_project(self.qsettings())

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -628,7 +628,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         self._julia_kernel_combobox_context_menu.popup(global_pos)
 
     @Slot(bool)
-    def _open_python_kernel_resource_dir(self, _=False):
+    def _open_python_kernel_resource_dir(self, _: bool = False) -> None:
         """Opens Python kernels resource dir."""
         try:
             index = self.ui.comboBox_python_kernel.view().selectedIndexes()[0]
@@ -639,7 +639,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         self.open_rsc_dir(item)
 
     @Slot(bool)
-    def _open_julia_kernel_resource_dir(self, _=False):
+    def _open_julia_kernel_resource_dir(self, _: bool = False) -> None:
         """Opens Julia kernels resource dir."""
         try:
             index = self.ui.comboBox_julia_kernel.view().selectedIndexes()[0]


### PR DESCRIPTION
PySide6 6.10.1 has signal connection issues that cannot be fixed in a reasonable way. E.g. connecting `QAbstractItemMode.dataChanged` to a perfectly valid slot causes a segfault.

Resolves #3223

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
