### PR TITLE
Renumber dock keyboard shortcuts in DB editor

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -722,7 +722,7 @@ class Ui_MainWindow(object):
 #if QT_CONFIG(tooltip)
         self.actionGitHub.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p>Open Spine-Toolbox repository in GitHub</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.alternative_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Alternative (Alt+5)", None))
+        self.alternative_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Alternative (Alt+6)", None))
 #if QT_CONFIG(accessibility)
         self.alternative_tree_view.setAccessibleName(QCoreApplication.translate("MainWindow", u"alternative tree", None))
 #endif // QT_CONFIG(accessibility)
@@ -748,7 +748,7 @@ class Ui_MainWindow(object):
         self.dockWidget_exports.setWindowTitle(QCoreApplication.translate("MainWindow", u"Exports", None))
         self.metadata_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Metadata", None))
         self.item_metadata_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Item metadata", None))
-        self.scenario_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Scenario tree (Alt+6)", None))
+        self.scenario_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Scenario tree (Alt+7)", None))
 #if QT_CONFIG(accessibility)
         self.scenario_tree_view.setAccessibleName(QCoreApplication.translate("MainWindow", u"scenario tree", None))
 #endif // QT_CONFIG(accessibility)
@@ -757,6 +757,6 @@ class Ui_MainWindow(object):
         self.menuEdit.setTitle(QCoreApplication.translate("MainWindow", u"&Edit", None))
         self.menuSession.setTitle(QCoreApplication.translate("MainWindow", u"Sess&ion", None))
         self.menuFile_2.setTitle(QCoreApplication.translate("MainWindow", u"&File", None))
-        self.entity_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Entity", None))
+        self.entity_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Entity (Alt+5)", None))
     # retranslateUi
 

--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
@@ -45,7 +45,7 @@
     <set>Qt::DockWidgetArea::AllDockWidgetAreas</set>
    </property>
    <property name="windowTitle">
-    <string>Alternative (Alt+5)</string>
+    <string>Alternative (Alt+6)</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -656,7 +656,7 @@
   </widget>
   <widget class="QDockWidget" name="scenario_dock_widget">
    <property name="windowTitle">
-    <string>Scenario tree (Alt+6)</string>
+    <string>Scenario tree (Alt+7)</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
@@ -859,7 +859,7 @@
   </widget>
   <widget class="QDockWidget" name="entity_dock_widget">
    <property name="windowTitle">
-    <string>Entity</string>
+    <string>Entity (Alt+5)</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QTabBar,
     QTreeView,
+    QWidget,
 )
 from sqlalchemy.engine.url import URL
 from spine_engine.utils.helpers import urls_equal
@@ -125,7 +126,7 @@ class SpineDBEditorBase(QMainWindow):
         self._export_items_dialog_state = None
         self.update_commit_enabled()
         self.last_view: ViewType | None = None
-        self.setup_focus_shortcuts()
+        self._setup_focus_shortcuts()
         self.table_name_from_item_type = {
             "parameter_value": self.ui.dockWidget_parameter_value.windowTitle(),
             "parameter_definition": self.ui.dockWidget_parameter_definition.windowTitle(),
@@ -937,36 +938,36 @@ class SpineDBEditorBase(QMainWindow):
             palette.setColor(QPalette.ColorRole.Window, color)
         dock.setPalette(palette)
 
-    def setup_focus_shortcuts(self):
+    def _setup_focus_shortcuts(self):
         # Direct focus shortcuts for widgets in the DB editor
-        QShortcut(QKeySequence("Alt+1"), self).activated.connect(lambda: self.focus_widget(self.ui.treeView_entity))
+        QShortcut(QKeySequence("Alt+1"), self).activated.connect(lambda: self._focus_widget(self.ui.treeView_entity))
         QShortcut(QKeySequence("Alt+3"), self).activated.connect(
-            lambda: self.focus_widget(self.ui.tableView_parameter_value)
+            lambda: self._focus_widget(self.ui.tableView_parameter_value)
         )
         QShortcut(QKeySequence("Alt+Shift+3"), self).activated.connect(
-            lambda: self.focus_widget(self.ui.tableView_parameter_definition)
+            lambda: self._focus_widget(self.ui.tableView_parameter_definition)
         )
         QShortcut(QKeySequence("Alt+4"), self).activated.connect(
-            lambda: self.focus_widget(self.ui.tableView_entity_alternative)
+            lambda: self._focus_widget(self.ui.tableView_entity_alternative)
         )
-        QShortcut(QKeySequence("Alt+5"), self).activated.connect(
-            lambda: self.focus_widget(self.ui.alternative_tree_view)
+        QShortcut(QKeySequence("Alt+5"), self).activated.connect(lambda: self._focus_widget(self.ui.entity_table_view))
+        QShortcut(QKeySequence("Alt+6"), self).activated.connect(
+            lambda: self._focus_widget(self.ui.alternative_tree_view)
         )
-        QShortcut(QKeySequence("Alt+6"), self).activated.connect(lambda: self.focus_widget(self.ui.scenario_tree_view))
+        QShortcut(QKeySequence("Alt+7"), self).activated.connect(lambda: self._focus_widget(self.ui.scenario_tree_view))
         QShortcut(QKeySequence("Alt+9"), self).activated.connect(
-            lambda: self.focus_widget(self.ui.treeView_parameter_value_list)
+            lambda: self._focus_widget(self.ui.treeView_parameter_value_list)
         )
 
-    @Slot()
-    def focus_widget(self, widget):
+    @Slot(QWidget)
+    def _focus_widget(self, widget: QWidget) -> None:
         """Focus a specific widget and make its dock visible if needed."""
         for dock in self.findChildren(QDockWidget):
             if widget in dock.findChildren(type(widget).__base__):
                 dock.raise_()
                 dock.setFocus()
                 widget.setFocus()
-                return True
-        return False
+                break
 
 
 class SpineDBEditor(TabularViewMixin, GraphViewMixin, StackedViewMixin, TreeViewMixin, SpineDBEditorBase):


### PR DESCRIPTION
Entity dock can now be focused with **Alt+5**, Alternatives with **Alt+6** and Scenario tree with **Alt+7**

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
