### PR TITLE
Collect data for auto filters from visible items only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 - The Entity table in Spine Database editor can now be properly filtered by selecting scenarios
   from the Scenario tree.
   When doing so, the table will show the entities that are visible in the selected scenario.
+- The column filters in the tables of Stacked view in Spine Database editor now contain only
+  visible items instead of all possible choices.
 
 ### Deprecated
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -236,9 +236,6 @@ class CompoundStackedModel(CompoundTableModel):
         self._filter_class_ids = filter_class_ids
         self._filter_timer.start()
 
-    def has_auto_filter(self, field: str) -> bool:
-        return field in self._auto_filter
-
     def has_auto_filter_empty_selected(self, field: str) -> bool:
         if field not in self._auto_filter:
             return True
@@ -252,18 +249,16 @@ class CompoundStackedModel(CompoundTableModel):
 
     def auto_filter_data_map(self, column_i: int) -> dict[str, Any]:
         data = {}
-        for model in self.sub_models:
-            for row in range(model.rowCount()):
-                index = model.index(row, column_i)
-                data[index.data()] = index.data(Qt.ItemDataRole.EditRole)
+        for sub_model, sub_row in self._row_map:
+            index = sub_model.index(sub_row, column_i)
+            data[index.data()] = index.data(Qt.ItemDataRole.EditRole)
         return data
 
     def auto_filter_data_list(self, column_i: int) -> list[str]:
         data = set()
-        for model in self.sub_models:
-            for row in range(model.rowCount()):
-                if x := model.index(row, column_i).data():
-                    data.add(x)
+        for sub_model, sub_row in self._row_map:
+            if x := sub_model.index(sub_row, column_i).data():
+                data.add(x)
         return sorted(data)
 
     @Slot(int, object)

--- a/spinetoolbox/spine_db_editor/widgets/custom_menus.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_menus.py
@@ -57,17 +57,12 @@ class AutoFilterMenu(FilterMenuBase[str]):
 
     @Slot()
     def _populate_data(self) -> None:
-        selected = self.filter.model().get_selected()
         if self._field in self._source_model.FIELDS_REQUIRING_FILTER_DATA_CONVERSION:
             self._display_value_to_edit_data = self._source_model.auto_filter_data_map(self._field_index)
             filter_data = [x for x in self._display_value_to_edit_data if x]
         else:
             filter_data = self._source_model.auto_filter_data_list(self._field_index)
-        all_selected = not self._source_model.has_auto_filter(self._field)
-        self.filter.model().set_list(filter_data, all_selected=all_selected)
-        if not all_selected:
-            empty_selected = self._source_model.has_auto_filter_empty_selected(self._field)
-            self.filter.model().set_selected(selected, empty_selected)
+        self.filter.model().set_list(filter_data, all_selected=True)
 
     def emit_filter_changed(self, valid_values: set[str | None]) -> None:
         """


### PR DESCRIPTION
The column filters of stacked tables work incrementally now.

Fixes #2047

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
