### PR TITLE
Fix Traceback when reopening DB editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -1013,6 +1013,13 @@ class GraphViewMixin:
         self.qsettings.endGroup()
         return file_path
 
+    def tear_down(self):
+        if not super().tear_down():
+            return False
+        self.db_mngr.items_added.disconnect(self._refresh_icons)
+        self.db_mngr.items_updated.disconnect(self._refresh_icons)
+        return True
+
     def closeEvent(self, event):
         """Handle close window.
 


### PR DESCRIPTION
This PR fixes a Traceback that could occur after reopening DB editor after using it in Graph view.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
