### PR TITLE
Fix Select superclass dialog

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -109,7 +109,7 @@ class MultiDBTreeItem(TreeItem):
         return next(iter(ids))
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.db_map_data_field(self.first_db_map, "name", default="")
 
     @property

--- a/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
@@ -175,7 +175,7 @@ class TreeViewMixin:
         dialog.show()
 
     def show_select_superclass_form(self, entity_class_item):
-        dialog = SelectSuperclassDialog(self, entity_class_item, self.db_mngr, *self.db_maps)
+        dialog = SelectSuperclassDialog(self, entity_class_item.name, self.db_mngr, *self.db_maps)
         dialog.show()
 
     @Slot()


### PR DESCRIPTION
Fixed a Traceback when opening the Select superclass dialog in DB editor.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
