### PR TITLE
Fix entity expandability in Entity tree

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -345,6 +345,17 @@ class EntityItem(MultiDBTreeItem):
             self._is_group = False
             self.parent_item.reposition_child(self.child_number())
 
+    def _polish_children(self, children):
+        """See base class."""
+        db_map_entity_element_ids = {
+            db_map: {el_id for ent in self.db_mngr.get_items(db_map, "entity") for el_id in ent["element_id_list"]}
+            for db_map in self.db_maps
+        }
+        for child in children:
+            child.set_has_children_initially(
+                any(child.db_map_id(db_map) in db_map_entity_element_ids.get(db_map, ()) for db_map in child.db_maps)
+            )
+
     def tear_down(self):
         super().tear_down()
         self._entity_group_fetch_parent.set_obsolete(True)

--- a/tests/spine_db_editor/mvcmodels/test_entity_tree_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_entity_tree_models.py
@@ -25,3 +25,39 @@ class TestEntityTreeModel:
         while len(model.root_item.children) != 2:
             QApplication.processEvents()
         assert [child.display_data for child in model.root_item.children] == ["Any", "Object (Any)"]
+
+    def test_entity_items_advertise_they_have_children(self, db_editor, db_mngr, db_map):
+        with db_map:
+            db_map.add_entity_class(name="A")
+            db_map.add_entity(entity_class_name="A", name="a")
+            db_map.add_entity_class(name="B")
+            db_map.add_entity(entity_class_name="B", name="b")
+            db_map.add_entity_class(dimension_name_list=["A", "B"])
+            db_map.add_entity(entity_class_name="A__B", entity_byname=["a", "b"])
+            db_map.add_entity_class(dimension_name_list=["A__B", "A__B"])
+            db_map.add_entity(entity_class_name="A__B__A__B", entity_byname=["a", "b", "a", "b"])
+        model = EntityTreeModel(db_editor, db_mngr, db_map)
+        model.build_tree()
+        model.root_item.fetch_more()
+        while len(model.root_item.children) != 4:
+            QApplication.processEvents()
+        assert [child.display_data for child in model.root_item.children] == ["A", "B", "A__B", "A__B__A__B"]
+        assert all(child.has_children() for child in model.root_item.children)
+        class_a = model.root_item.children[0]
+        class_a.fetch_more()
+        while len(class_a.children) != 1:
+            QApplication.processEvents()
+        assert [entity_item.display_data for entity_item in class_a.children] == ["a"]
+        assert all(entity_item.has_children() for entity_item in class_a.children)
+        entity_a = class_a.children[0]
+        entity_a.fetch_more()
+        while len(entity_a.children) != 1:
+            QApplication.processEvents()
+        assert [entity_item.display_data for entity_item in entity_a.children] == ["٭ ǀ b"]
+        assert all(entity_item.has_children() for entity_item in entity_a.children)
+        relationship_a_b = entity_a.children[0]
+        relationship_a_b.fetch_more()
+        while len(relationship_a_b.children) != 1:
+            QApplication.processEvents()
+        assert [relationship.display_data for relationship in relationship_a_b.children] == ["٭ ǀ ٭ ǀ ٭ ǀ ٭"]
+        assert all(not relationship.has_children() for relationship in relationship_a_b.children)


### PR DESCRIPTION
This PR fixes an issue where ND entities at deeper level in Entity Tree did not always show the little arrow that allowed viewing the other ND entities they were elements of.

Re #3242

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
