### PR TITLE
Fix Traceback from Scenario Tree

### DIFF
--- a/spinetoolbox/spine_db_editor/selection_for_filtering.py
+++ b/spinetoolbox/spine_db_editor/selection_for_filtering.py
@@ -209,6 +209,8 @@ class ScenarioSelectionForFiltering(QObject):
                 continue
             db_map = parent_index.data(DB_MAP_ROLE)
             scenario_id = index.data(ITEM_ID_ROLE)
+            if scenario_id is None:
+                continue
             selection.setdefault(db_map, set()).add(scenario_id)
         if not selection:
             selection = Asterisk

--- a/tests/spine_db_editor/test_selection_for_filtering.py
+++ b/tests/spine_db_editor/test_selection_for_filtering.py
@@ -592,3 +592,17 @@ class TestScenarioSelectionForFiltering:
             mock_signal.emit.assert_not_called()
             view.selectionModel().select(model.index(1, 0, scenario_index), QItemSelectionModel.SelectionFlag.Select)
             mock_signal.emit.assert_not_called()
+
+    def test_selecting_add_new_scenario_item_does_not_affect_selection(self, db_editor, logger):
+        view = db_editor.ui.scenario_tree_view
+        model = view.model()
+        database_index = model.index(0, 0)
+        assert database_index.data() == "TestScenarioSelectionForFiltering_db"
+        assert model.rowCount(database_index) == 1
+        scenario_index = model.index(0, 0, database_index)
+        assert scenario_index.data() == "Type new scenario name here..."
+        filter_selection = db_editor._scenario_selection_for_filtering
+        with mock.patch.object(filter_selection, "scenario_selection_changed") as mock_signal:
+            mock_signal.emit = mock.MagicMock()
+            view.selectionModel().select(scenario_index, QItemSelectionModel.SelectionFlag.ClearAndSelect)
+            mock_signal.emit.assert_not_called()


### PR DESCRIPTION
This PR fixes a Traceback that would appear when selecting the "Type new scenario name here..." item in Scenario tree.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
