### PR TITLE
Fix duplicate database mappings when opening, adding or creating databases in DB editor

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1779,7 +1779,7 @@ def display_byte_size(size_bytes: int) -> tuple[float | int, str]:
 
 
 def normcase_database_url_path(url: str) -> str:
-    if not url.startswith("sqlite://"):
+    if not url.startswith("sqlite:///"):
         return url
     path = url[len("sqlite:///") :]
     return "sqlite:///" + os.path.normcase(path)

--- a/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
@@ -16,9 +16,10 @@ import os
 from PySide6.QtCore import QPoint, Slot
 from PySide6.QtGui import QFont, QIcon
 from PySide6.QtWidgets import QMenu, QStatusBar, QToolButton
+from sqlalchemy.engine.url import URL
 from ...config import MAINWINDOW_SS, ONLINE_DOCUMENTATION_URL
 from ...font import TOOLBOX_FONT
-from ...helpers import CharIconEngine, open_url
+from ...helpers import CharIconEngine, normcase_database_url_path, open_url
 from ...widgets.multi_tab_window import MultiTabWindow
 from ...widgets.settings_widget import SpineDBEditorSettingsWidget
 from ..editors import db_editor_registry
@@ -241,7 +242,12 @@ def open_db_editor(db_urls, db_mngr, reuse_existing_editor):
         if multi_db_editor.tab_load_success:
             multi_db_editor.show()
         return
-    existing = _get_existing_spine_db_editor(list(map(str, db_urls)))
+    normcased_urls = []
+    for url in db_urls:
+        if isinstance(url, URL):
+            url = url.render_as_string(hide_password=False)
+        normcased_urls.append(normcase_database_url_path(url))
+    existing = _get_existing_spine_db_editor(normcased_urls)
     if existing is None:
         multi_db_editor.add_new_tab(db_urls)
     else:

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -255,7 +255,7 @@ class SpineDBEditorBase(QMainWindow):
         self.qsettings.endGroup()
         if not file_path:
             return
-        url = "sqlite:///" + os.path.normcase(file_path)
+        url = "sqlite:///" + file_path
         self.load_db_urls([url])
 
     @Slot(bool)
@@ -267,7 +267,7 @@ class SpineDBEditorBase(QMainWindow):
         self.qsettings.endGroup()
         if not file_path:
             return
-        url = "sqlite:///" + os.path.normcase(file_path)
+        url = "sqlite:///" + file_path
         self.load_db_urls(self.db_urls + [url])
 
     @Slot()
@@ -283,7 +283,7 @@ class SpineDBEditorBase(QMainWindow):
             os.remove(file_path)
         except OSError:
             pass
-        url = "sqlite:///" + os.path.normcase(file_path)
+        url = "sqlite:///" + file_path
         self.load_db_urls([url], create=True)
 
     @Slot()

--- a/tests/spine_db_editor/widgets/test_multi_spine_db_editor.py
+++ b/tests/spine_db_editor/widgets/test_multi_spine_db_editor.py
@@ -17,6 +17,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 from PySide6.QtCore import QPoint, QSettings
 from PySide6.QtWidgets import QApplication
+from spinetoolbox.helpers import normcase_database_url_path
 from spinetoolbox.multi_tab_windows import MultiTabWindowRegistry
 from spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor import MultiSpineDBEditor, open_db_editor
 from spinetoolbox.spine_db_manager import SpineDBManager
@@ -93,7 +94,7 @@ class TestOpenDBEditor(TestCaseWithQApplication):
                 "spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.db_editor_registry",
                 self._db_editor_registry,
             ),
-            patch("spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.MultiSpineDBEditor.show") as mock_show,
+            patch("spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.MultiSpineDBEditor.show"),
         ):
             self.assertFalse(self._db_editor_registry.has_windows())
             window = MultiSpineDBEditor(self._db_mngr, [])
@@ -103,5 +104,5 @@ class TestOpenDBEditor(TestCaseWithQApplication):
             open_db_editor([self._db_url], self._db_mngr, reuse_existing_editor=True)
             self.assertEqual(window.tab_widget.count(), 2)
             tab = window.tab_widget.widget(1)
-            self.assertEqual(tab.db_urls, [self._db_url])
+            self.assertEqual(tab.db_urls, [normcase_database_url_path(self._db_url)])
             self._close_windows()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -551,6 +551,7 @@ class TestDisplayByteSize:
 class TestNormcaseDatabaseUrlPath:
     def test_correctness(self):
         assert normcase_database_url_path("mysql://example.com/Path/MY_DB") == "mysql://example.com/Path/MY_DB"
+        assert normcase_database_url_path("sqlite://") == "sqlite://"
         if sys.platform == "win32":
             assert (
                 normcase_database_url_path("sqlite:///C:\\Users\\SansSerif\\in.sqlite")


### PR DESCRIPTION
This fixes a bug in DB editor where same databases in different editor tabs did not get the same updates.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
