### PR TITLE
Add missing Slot decoration to support PySide6 6.10.1

### DIFF
--- a/spinetoolbox/project_item/specification_editor_window.py
+++ b/spinetoolbox/project_item/specification_editor_window.py
@@ -217,6 +217,7 @@ class SpecificationEditorWindowBase(Generic[UI], QMainWindow):
         self.setWindowTitle(title)
         self.windowTitleChanged.emit(self.windowTitle())
 
+    @Slot(bool)
     def _save(self, exiting: bool = False) -> bool:
         """Saves spec.
 


### PR DESCRIPTION
The unit tests tripped at this missing `Slot` decoration with Python 3.14.2 and `PySide6` 6.10.1.

`PySide6` 6.10.1 and Python 3.14 are still not enabled as Spine Engine server does not seem to work with Python 3.14.2.

Re #3189

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
