### PR TITLE
Enable Python 3.14

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -57,6 +57,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m pip install -r dev-requirements.txt
+        python -m pip install PySide6==6.10.0  # Temporary solution; unit tests fail inexplicably on 6.10.1
     - name: Run post-install command
       if: ${{ inputs.post-installation-command }}
       run:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spine Toolbox
 Link to the documentation: [https://spine-toolbox.readthedocs.io/en/latest/?badge=latest](https://spine-toolbox.readthedocs.io/en/latest/?badge=latest)
 
-[![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13-blue.svg)](https://www.python.org/downloads/release/python-3120/)
+[![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14-blue.svg)](https://www.python.org/downloads/release/python-3120/)
 [![Documentation Status](https://readthedocs.org/projects/spine-toolbox/badge/?version=latest)](https://spine-toolbox.readthedocs.io/en/latest/?badge=latest)
 [![Test suite](https://github.com/spine-tools/Spine-Toolbox/actions/workflows/test_runner.yml/badge.svg)](https://github.com/spine-tools/Spine-Toolbox/actions/workflows/test_runner.yml)
 [![codecov](https://codecov.io/gh/spine-tools/Spine-Toolbox/branch/master/graph/badge.svg)](https://codecov.io/gh/spine-tools/Spine-Toolbox)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "PySide6 >= 6.9, !=6.10.1",
+    "PySide6 >= 6.9",
     "jupyter_client >=6.0",
     "qtconsole >=5.1",
     "spinedb_api>=0.36.2",

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -622,6 +622,7 @@ class GraphViewMixin:
         self.collapsed_db_map_entity_ids.clear()
         self.build_graph(force=force)
 
+    @Slot()
     def build_graph(self, persistent: bool = False, force: bool = False) -> None:
         """Builds graph from current selection of items.
 

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -215,7 +215,7 @@ class StackedViewMixin:
     def _handle_values_inserted(self, parent: QModelIndex, first: int, last: int) -> None:
         self._clear_table_related_caches()
 
-    @Slot(list, QAbstractItemModel.LayoutChangeHint)
+    @Slot(list, int)
     def _handle_value_model_layout_changed(
         self, parents: list[QPersistentModelIndex], hint: QAbstractItemModel.LayoutChangeHint
     ) -> None:


### PR DESCRIPTION
Toolbox runs fine on Python 3.14 and PySide6 6.10.1. Unit tests do not, so we force PySide 6.10.0 in unit tests
which means we cannot include Python 3.14 in the test matrix.

Re #3189

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
