### PR TITLE
Fix spurios filter icon sometimes appearing on connections

### DIFF
--- a/spinetoolbox/project_item/logging_connection.py
+++ b/spinetoolbox/project_item/logging_connection.py
@@ -12,6 +12,7 @@
 
 """Contains logging connection and jump classes."""
 from spine_engine.project_item.connection import ConnectionBase, FilterSettings, Jump, ResourceConvertingConnection
+from spine_engine.project_item.project_item_resource import ProjectItemResource
 from spinedb_api import DatabaseMapping, SpineDBAPIError, SpineDBVersionError
 from spinedb_api.filters.alternative_filter import ALTERNATIVE_FILTER_TYPE
 from spinedb_api.filters.scenario_filter import SCENARIO_FILTER_TYPE
@@ -120,18 +121,19 @@ class HeadlessConnection(ResourceConvertingConnection):
         if self._legacy_resource_filter_ids is not None:
             self._convert_legacy_resource_filter_ids_to_filter_settings()
 
-    def replace_resources_from_source(self, old, new):
+    def replace_resources_from_source(self, old: list[ProjectItemResource], new: list[ProjectItemResource]) -> None:
         """Replaces existing resources by new ones.
 
         Args:
-            old (list of ProjectItemResource): old resources
-            new (list of ProjectItemResource): new resources
+            old: old resources
+            new: new resources
         """
         for old_resource, new_resource in zip(old, new):
             self._resources.discard(old_resource)
             old_filters = self._filter_settings.known_filters.pop(old_resource.label, None)
             if new_resource.type_ == "database":
-                self._resources.add(new_resource)
+                if new_resource.filterable:
+                    self._resources.add(new_resource)
                 if old_filters is not None:
                     self._filter_settings.known_filters[new_resource.label] = old_filters
 

--- a/tests/project_item/test_logging_connection.py
+++ b/tests/project_item/test_logging_connection.py
@@ -48,6 +48,18 @@ class TestLoggingConnection(unittest.TestCase):
         )
         connection.tear_down()
 
+    def test_replace_resource_from_source_with_non_filterable_database_resource(self):
+        toolbox = MagicMock()
+        connection = LoggingConnection("source", "bottom", "destination", "top", toolbox=toolbox)
+        connection.link = MagicMock()
+        original = database_resource("source", "sqlite:///db.sqlite", label="database", filterable=False)
+        connection.receive_resources_from_source([original])
+        self.assertEqual(connection.database_resources, set())
+        modified = database_resource("source", "sqlite:///db2.sqlite", label="new database", filterable=False)
+        connection.replace_resources_from_source([original], [modified])
+        self.assertEqual(connection.database_resources, set())
+        connection.tear_down()
+
     def test_set_filter_default_online_status(self):
         toolbox = MagicMock()
         filter_settings = FilterSettings()


### PR DESCRIPTION
This fixes a bug where filters could be set up for connections that should not be filtered.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
