### PR TITLE
Change version numbering scheme 

### DIFF
--- a/.github/workflows/execution_tests.yml
+++ b/.github/workflows/execution_tests.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
+          fetch-depth: 0
+      - name: Version from Git tags
+        run: git describe --tags
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,12 @@ spinetoolbox = "spinetoolbox.main:main"
 spine-db-editor = "spinetoolbox.spine_db_editor.main:main"
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2", "wheel", "build"]
+requires = ["setuptools>=80", "setuptools_scm>=8", "wheel", "build"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 version_file = "spinetoolbox/_version.py"
-# default: guess-next-dev, alternatives: post-release, no-guess-dev
-version_scheme = "release-branch-semver"
+version_scheme = "guess-next-dev"
 
 [tool.setuptools]
 zip-safe = false

--- a/spinetoolbox/version.py
+++ b/spinetoolbox/version.py
@@ -45,21 +45,14 @@ if dev:
     if match := re.search(r"[0-9]+", rel):
         split = match.span()[0]
         releaselevel, serial = rel[:split], int(rel[split:])
-
-        # name cleanup
         del split
     else:
         # shouldn't happen
         releaselevel, serial = rel, 0
-
-    # name cleanup
     del match, rel
 else:
     # compat: move away gradually
     releaselevel, serial = "final", 0
-
-# name cleanup
 del dev
-
 __version_info__ = VersionInfo(major, minor, micro, releaselevel, serial)
 __version__ = str(__version_info__)


### PR DESCRIPTION
This PR changes our versioning scheme from `release-branch-semver` to `guess-next-dev`. We want to always just bump the most minor version number when guessing the next release version since we are not using release branches.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
