### PR TITLE
Fix sorting by parameter group priority

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -521,7 +521,7 @@ class SingleParameterValueModel(
         item = self._mapped_table[item_id]
         byname = order_key_from_names(item["entity_byname"])
         parameter_group_id = item["parameter_group_id"]
-        group_priority = math.inf
+        group_priority = -math.inf
         if parameter_group_id is not None:
             group = self.db_map.mapped_table("parameter_group")[parameter_group_id]
             if group.is_valid():
@@ -529,7 +529,7 @@ class SingleParameterValueModel(
 
         parameter_name = order_key(item["parameter_name"])
         alt_name = order_key(item["alternative_name"])
-        return byname, group_priority, parameter_name, alt_name
+        return byname, -group_priority, parameter_name, alt_name
 
     def row_for_associated_metadata_item(self, metadata_item: PublicItem) -> int | None:
         try:

--- a/tests/spine_db_editor/mvcmodels/test_compound_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_compound_models.py
@@ -925,8 +925,8 @@ class TestCompoundParameterValueModel(TestBase):
 
     def test_group_data(self):
         with self._db_map:
-            self._db_map.add_parameter_group(name="Group A", color="102030", priority=3)
-            self._db_map.add_parameter_group(name="Group B", color="090807", priority=2)
+            self._db_map.add_parameter_group(name="Group A", color="102030", priority=2)
+            self._db_map.add_parameter_group(name="Group B", color="090807", priority=3)
             self._db_map.add_entity_class(name="Widget")
             self._db_map.add_entity(entity_class_name="Widget", name="gadget")
             self._db_map.add_entity(entity_class_name="Widget", name="object")


### PR DESCRIPTION
This fixes a bug where parameter values with lower group priorities appeared before higher priorities in Parameter value table.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
