### PR TITLE
Lift Julia version restriction in Install Julia Wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- Install Julia wizard now installs latest Julia instead of Julia 1.11.
+
 ### Deprecated
 
 ### Removed

--- a/spinetoolbox/widgets/install_julia_wizard.py
+++ b/spinetoolbox/widgets/install_julia_wizard.py
@@ -197,7 +197,6 @@ class InstallJuliaPage(QWizardProcessPage):
             "-m",
             "jill",
             "install",
-            "1.11",  # as of 17.10.2025, SpineOpt doesn't work with Julia >= 1.12; revise later!
             "--confirm",
             "--install_dir",
             self.field("install_dir"),


### PR DESCRIPTION
SpineOpt supports Julia 1.12 now.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
