### PR TITLE
Accept comma-decimal input in DB editor value/default cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- Parameter and default-value cells in the DB editor now accept comma-decimal
+  input (e.g. `1,5`) under Finnish/German/etc. locales.  Previously such input
+  fell through both `int()` and `float()` and was silently stored as a string
+  with `default_type='str'`, causing downstream tools (e.g. FlexTool) to read
+  the value as text instead of a number.
+
 ### Security
 
 ## [0.10.8]

--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -15,8 +15,9 @@
 from __future__ import annotations
 import bisect
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 import datetime
+import locale
 from enum import Enum, unique
 import functools
 import gc
@@ -834,8 +835,38 @@ def get_open_file_name_in_last_dir(
     return filename, selected_filter
 
 
+@contextmanager
+def system_lc_numeric():
+    """Temporarily switches ``LC_NUMERIC`` to the user's system locale.
+
+    Toolbox runs with ``LC_NUMERIC='C'`` set at startup (see ``ui_main``
+    and ``spine_db_editor/main``) so that ``float()`` and other ``.``-decimal
+    parsers behave consistently regardless of OS locale.  This context
+    manager flips ``LC_NUMERIC`` to the user's system locale for the
+    duration of the ``with`` block — needed for ``locale.atof`` to accept
+    comma-decimal input on Finnish/German/etc. locales — and restores the
+    previous value on exit.
+
+    Duplicated from ``widgets.custom_qtableview.system_lc_numeric``; both
+    sites should converge on this module in a follow-up.
+    """
+    saved = locale.getlocale(locale.LC_NUMERIC)
+    locale.setlocale(locale.LC_NUMERIC, "")
+    try:
+        yield
+    finally:
+        locale.setlocale(locale.LC_NUMERIC, saved)
+
+
 def try_number_from_string(text: str) -> Union[float, int, str]:
     """Tries to convert a string to integer or float.
+
+    Accepts both ``.``-decimal (e.g. ``"1.5"``) and ``,``-decimal
+    (e.g. ``"1,5"``) input.  ``.``-decimals are parsed locale-independently
+    via ``float()``.  ``,``-decimals are parsed via ``locale.atof`` under
+    the user's system locale, gated on "exactly one ``,`` and no ``.``"
+    so locale-ambiguous strings like ``"1,000"`` stay as strings rather
+    than silently parsing to ``1.0`` or ``1000.0`` depending on locale.
 
     Args:
         text: string to convert
@@ -849,6 +880,10 @@ def try_number_from_string(text: str) -> Union[float, int, str]:
         try:
             return float(text)
         except ValueError:
+            if isinstance(text, str) and text.count(",") == 1 and "." not in text:
+                with suppress(ValueError, locale.Error):
+                    with system_lc_numeric():
+                        return locale.atof(text)
             return text
     except TypeError:
         return text

--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -16,7 +16,7 @@ import locale
 from typing import Any, Optional, Union
 from PySide6.QtGui import QColor
 from spinedb_api.helpers import string_to_bool as base_string_to_bool
-from spinetoolbox.helpers import DB_ITEM_SEPARATOR
+from spinetoolbox.helpers import DB_ITEM_SEPARATOR, system_lc_numeric
 
 
 def string_to_display_icon(x: str) -> Optional[int]:
@@ -96,10 +96,18 @@ def string_to_parameter_value(str_value: str) -> Any:
     try:
         return float(str_value)
     except ValueError:
-        try:
-            return locale.atof(str_value)
-        except ValueError:
-            pass
+        # ``locale.atof`` was always called here but under the C numeric
+        # locale Toolbox sets at startup; ``,``-decimal input (typed by
+        # users on Finnish/German/etc. locales) silently fell through to
+        # the string branch.  Switch to the user's system locale for the
+        # call and gate on "one ``,``, no ``.``" so ``"1,000"``-style
+        # locale-ambiguous strings stay unparsed.
+        if str_value.count(",") == 1 and "." not in str_value:
+            try:
+                with system_lc_numeric():
+                    return locale.atof(str_value)
+            except (ValueError, locale.Error):
+                pass
     if str_value == TRUE_STRING:
         return True
     if str_value == FALSE_STRING:

--- a/tests/spine_db_editor/test_helpers.py
+++ b/tests/spine_db_editor/test_helpers.py
@@ -98,9 +98,21 @@ class TestStringToParameterValue(unittest.TestCase):
     def test_numeric_values(self):
         with mock.patch("spinetoolbox.spine_db_editor.helpers.locale.atof") as mock_atof:
             mock_atof.side_effect = lambda x: float(x.replace(",", "."))
-            self.assertEqual(string_to_parameter_value("2,3"), 2.3)
-            self.assertEqual(string_to_parameter_value("2.3"), 2.3)
+            with mock.patch("spinetoolbox.helpers.locale.setlocale"):
+                self.assertEqual(string_to_parameter_value("2,3"), 2.3)
+                self.assertEqual(string_to_parameter_value("2.3"), 2.3)
         self.assertEqual(string_to_parameter_value("2.3"), 2.3)
+
+    def test_locale_ambiguous_numeric_strings_stay_strings(self):
+        # ``"1,000"`` could be 1.0 (Finnish locale) or 1000.0 (US locale).
+        # Don't guess — leave it as a string and let the user disambiguate.
+        with mock.patch("spinetoolbox.spine_db_editor.helpers.locale.atof") as mock_atof:
+            mock_atof.side_effect = lambda x: float(x.replace(",", "."))
+            self.assertEqual(string_to_parameter_value("1,000,000"), "1,000,000")
+            self.assertEqual(string_to_parameter_value("1.5,3"), "1.5,3")
+            # ``locale.atof`` should never be reached for locale-ambiguous
+            # input under the gated path.
+            mock_atof.assert_not_called()
 
 
 class TestInputStringToInt(unittest.TestCase):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -217,6 +217,20 @@ class TestHelpers(TestCaseWithQApplication):
         self.assertEqual(try_number_from_string("23"), 23)
         self.assertEqual(try_number_from_string("2.3"), 2.3)
 
+    def test_try_number_from_string_comma_decimal(self):
+        # Users on locales with ``,`` decimal separator (Finnish, German,
+        # etc.) need ``"1,5"`` to parse as the float 1.5.  Mocked here so
+        # the test doesn't depend on the system locale actually being
+        # configured with a comma-decimal in CI.
+        with patch("spinetoolbox.helpers.locale.atof") as mock_atof:
+            mock_atof.side_effect = lambda x: float(x.replace(",", "."))
+            with patch("spinetoolbox.helpers.locale.setlocale"):
+                self.assertEqual(try_number_from_string("1,5"), 1.5)
+                # Two commas / a period present → locale-ambiguous,
+                # leave as string rather than guessing.
+                self.assertEqual(try_number_from_string("1,000,000"), "1,000,000")
+                self.assertEqual(try_number_from_string("1.0,5"), "1.0,5")
+
     def test_select_julia_executable(self):
         with TemporaryDirectory() as temp_dir:
             executable = Path(temp_dir, "julia.exe")


### PR DESCRIPTION
Closes #3316.

## Summary

- DB editor cell edits go through `try_number_from_string` (typed) or `string_to_parameter_value` (pasted). Both used `float()` (locale-independent — `.`-only) and then either returned the original string or called `locale.atof` under the C numeric locale Toolbox sets at startup. On `,`-decimal locales (Finnish, German, etc.) users typing `1,5` into a default-value cell ended up with the string `"1,5"` and `default_type='str'`, propagating type confusion to downstream tools (FlexTool reported the symptom).
- Setting the parameter's "valid types" to `float` does **NOT** prevent this. The default-value delegate (`custom_delegates.py:326-333`) never consults `parameter_type_list` when coercing — it hands the editor's value straight to `to_database`. The whitelist is a read-only validation flag (red `❗` indicator drawn by `TypeValidationIndicatorMixin.paint`), not a coercion path; the bytes are already on disk as `str` by the time the indicator lights up.
- This PR wraps the `locale.atof` fallback in a `system_lc_numeric()` context manager so it picks up the user's actual system locale. The fallback is gated on "exactly one `,` and no `.`" so locale-ambiguous input like `"1,000"` (could be 1.0 on Finnish or 1000.0 on US) stays as a string rather than silently parsing to the wrong number.
- Adds `system_lc_numeric` to `spinetoolbox.helpers` for use in places that can't import from `widgets.custom_qtableview` (which has the same context manager — both sites should converge in a follow-up).

## Test plan

- [x] `tests/test_helpers.py::TestHelpers::test_try_number_from_string` — preserved; `"text"`/`"23"`/`"2.3"` still classify the same way.
- [x] `tests/test_helpers.py::TestHelpers::test_try_number_from_string_comma_decimal` — new; `"1,5"` → 1.5, ambiguous strings (`"1,000,000"`, `"1.0,5"`) stay as strings.
- [x] `tests/spine_db_editor/test_helpers.py::TestStringToParameterValue::test_numeric_values` — updated to mock `locale.setlocale` alongside the existing `locale.atof` mock so the test doesn't depend on a comma-decimal locale being available in CI.
- [x] `tests/spine_db_editor/test_helpers.py::TestStringToParameterValue::test_locale_ambiguous_numeric_strings_stay_strings` — new; checks `locale.atof` is never reached for `"1,000,000"`-style strings.
- [ ] Manual reproduction on a Finnish-locale machine: open DB editor, set a parameter's "valid types" to `float`, type `1,5` into a default-value cell, confirm the cell stores as `(b'1.5', 'float')` not `(b'"1,5"', 'str')` and no red `❗` indicator appears.

## Out of scope (follow-ups)

- `system_lc_numeric` is now duplicated in `spinetoolbox.helpers` and `spinetoolbox.widgets.custom_qtableview`. Either delete the latter and import the former, or have both re-export from a shared location. Held back to keep this PR's diff minimal.
- Other paste paths in `widgets/custom_qtableview.py` (lines 424, 525, 666, 802) already wrap `locale.atof` in `system_lc_numeric`, so they're not affected.
