### PR TITLE
Fix header table scrolling in pivot view

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'spine_db_editor_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.0
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -1285,6 +1285,16 @@ class PivotTableView(CopyPasteTableView):
         for header_table in (self._left_header_table, self._top_header_table, self._top_left_header_table):
             header_table.verticalHeader().setDefaultSectionSize(default_section_size)
 
+    def setHorizontalScrollMode(self, mode):
+        super().setHorizontalScrollMode(mode)
+        for header_table in (self._top_left_header_table, self._top_header_table, self._left_header_table):
+            header_table.setHorizontalScrollMode(mode)
+
+    def setVerticalScrollMode(self, mode):
+        super().setVerticalScrollMode(mode)
+        for header_table in (self._top_left_header_table, self._top_header_table, self._left_header_table):
+            header_table.setVerticalScrollMode(mode)
+
     def resizeEvent(self, ev):
         super().resizeEvent(ev)
         self._update_header_tables_geometry()

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -17,7 +17,7 @@ import io
 import itertools
 from unittest import mock
 from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, Qt
-from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtWidgets import QAbstractItemView, QApplication, QMessageBox
 import pytest
 from spinedb_api import Array, DatabaseMapping, import_functions
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
@@ -1187,3 +1187,15 @@ class TestPivotTableView(TestBase):
             [None, None, None, None, None, None, None],
         ]
         assert_table_model_data(pivot_model, expected, self)
+
+    def test_set_scroll_modes(self):
+        view = self._db_editor.ui.pivot_table
+        for scroll_mode in (QAbstractItemView.ScrollMode.ScrollPerItem, QAbstractItemView.ScrollMode.ScrollPerPixel):
+            view.setHorizontalScrollMode(scroll_mode)
+            self.assertEqual(view.horizontalScrollMode(), scroll_mode)
+            for header_table in (view._top_left_header_table, view._top_header_table, view._left_header_table):
+                self.assertEqual(header_table.horizontalScrollMode(), scroll_mode)
+            view.setVerticalScrollMode(scroll_mode)
+            self.assertEqual(view.verticalScrollMode(), scroll_mode)
+            for header_table in (view._top_left_header_table, view._top_header_table, view._left_header_table):
+                self.assertEqual(header_table.verticalScrollMode(), scroll_mode)


### PR DESCRIPTION
This PR fixes a bug where the horizontal header scrolling was not in sync with the table in DB Editor's pivot view.

Fixes #3323

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
