### PR TITLE
Fix entity duplication in DB Editor

### DIFF
--- a/spinetoolbox/cache_graphs.py
+++ b/spinetoolbox/cache_graphs.py
@@ -47,8 +47,6 @@ class GraphBase:
 
 
 class SuperclassGraphBase(GraphBase):
-    INVALIDATING_ITEM_TYPES: ClassVar[set[str]] = {"entity_class", "superclass_subclass"}
-
     def is_any_id_reachable(self, db_map: DatabaseMapping, source_id: TempId, target_ids: set[TempId]) -> bool:
         if db_map not in self._graphs:
             self._graphs[db_map] = self._build_graph(db_map)
@@ -67,6 +65,8 @@ class SuperclassGraphBase(GraphBase):
 
 
 class RelationshipClassGraph(SuperclassGraphBase):
+    INVALIDATING_ITEM_TYPES: ClassVar[set[str]] = {"entity_class", "superclass_subclass"}
+
     @staticmethod
     def _build_graph(db_map: DatabaseMapping) -> nx.DiGraph:
         graph = _build_graph(db_map, "entity_class", "dimension_id_list")
@@ -78,6 +78,8 @@ class RelationshipClassGraph(SuperclassGraphBase):
 
 
 class RelationshipGraph(SuperclassGraphBase):
+    INVALIDATING_ITEM_TYPES: ClassVar[set[str]] = {"entity", "entity_class", "superclass_subclass"}
+
     @staticmethod
     def _build_graph(db_map: DatabaseMapping) -> nx.DiGraph:
         return _build_graph(db_map, "entity", "element_id_list")

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -268,10 +268,10 @@ class SpineDBWorker(QObject):
             added, updated, errors = self._db_map.add_update_items(item_type, *orig_items, check=check)
         if errors:
             self._db_mngr.error_msg.emit({self._db_map: errors})
-        self._db_mngr.update_icons(self._db_map, item_type, added + updated)
-        self._wake_up_parents(item_type, added)
         self._db_mngr.items_added.emit(item_type, {self._db_map: added})
         self._db_mngr.items_updated.emit(item_type, {self._db_map: updated})
+        self._db_mngr.update_icons(self._db_map, item_type, added + updated)
+        self._wake_up_parents(item_type, added)
         return added, updated
 
     @busy_effect

--- a/tests/spine_db_editor/widgets/test_custom_qtreeview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtreeview.py
@@ -13,7 +13,7 @@
 """Unit tests for DB editor's custom ``QTreeView`` classes."""
 
 from unittest import mock
-from PySide6.QtCore import QItemSelection, QItemSelectionModel, Qt
+from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, Qt
 from PySide6.QtWidgets import QApplication
 import pytest
 from spinedb_api import (
@@ -733,6 +733,44 @@ class TestEntityTreeViewWithExistingMultidimensionalEntities:
             data = db_map.query(db_map.entity_sq).all()
             assert len(data) == 4
             assert {i.name for i in data} == {"object_11", "object_12", "object_22", "object_11__object_22"}
+
+    def test_duplicate_element(self, entity_tree_model, db_mngr, db_map, db_editor):
+        o11_id = db_map.entity(entity_class_name="object_class_1", name="object_11")["id"]
+        r1_id = db_map.entity(entity_class_name="relationship_class", entity_byname=("object_11", "object_21"))["id"]
+        assert db_mngr.relationship_graph.is_any_id_reachable(db_map, r1_id, {o11_id})
+        view = db_editor.ui.treeView_entity
+        model = entity_tree_model
+        root_index = model.index(0, 0)
+        model.fetchMore(root_index)
+        while model.rowCount(root_index) != 3:
+            QApplication.processEvents()
+        class_index = model.index(0, 0, root_index)
+        assert class_index.data() == "object_class_1"
+        model.fetchMore(class_index)
+        while model.rowCount(class_index) != 2:
+            QApplication.processEvents()
+        object_index = model.index(0, 0, class_index)
+        assert object_index.data() == "object_11"
+        view.selectionModel().setCurrentIndex(object_index, QItemSelectionModel.SelectionFlag.ClearAndSelect)
+        view._context_item = model.item_from_index(object_index)
+        view.duplicate_entity()
+        QApplication.processEvents()
+        root_index = model.index(0, 0)
+        model.fetchMore(root_index)
+        while model.rowCount(root_index) != 3:
+            QApplication.processEvents()
+        class_index = model.index(0, 0, root_index)
+        assert class_index.data() == "object_class_1"
+        model.fetchMore(class_index)
+        while model.rowCount(class_index) != 3:
+            QApplication.processEvents()
+        object_index = model.index(1, 0, class_index)
+        assert object_index.data() == "object_11 (1)"
+        model.fetchMore(object_index)
+        while model.rowCount(object_index) != 2:
+            QApplication.processEvents()
+        assert model.index(0, 0, object_index).data() == "٭ ǀ object_21"
+        assert model.index(1, 0, object_index).data() == "٭ ǀ object_22"
 
     @staticmethod
     def _rename_class(class_name, db_editor):


### PR DESCRIPTION
This PR fixes a crash when an entity that is also an element of another entity is duplicated in DB Editor.

Fixes #3325

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
