### PR TITLE
Fix minor bug with empty rows

### DIFF
--- a/spinetoolbox/mvcmodels/empty_row_model.py
+++ b/spinetoolbox/mvcmodels/empty_row_model.py
@@ -78,6 +78,26 @@ class EmptyRowModel(MinimalTableModel):
         self.set_rows_to_default(first, last)
         self.dataChanged.connect(self._handle_data_changed)
 
+    def _default_row(self) -> list:
+        default_row = []
+        for column in range(self.columnCount()):
+            try:
+                field = self.header[column]
+            except IndexError:
+                default = None
+            else:
+                default = self.default_row.get(field)
+            default_row.append(default)
+        return default_row
+
+    def defaulted_rows(self) -> list[int]:
+        default_row = self._default_row()
+        rows = []
+        for i, row in enumerate(self._main_data):
+            if row == default_row:
+                rows.append(i)
+        return rows
+
     def set_rows_to_default(self, first: int, last: Optional[int] = None) -> None:
         """Sets default data in newly inserted rows."""
         if last is None:
@@ -86,14 +106,7 @@ class EmptyRowModel(MinimalTableModel):
         if first >= self.rowCount() or last < 0:
             return
         column_count = self.columnCount()
-        default_row = []
-        for column in range(column_count):
-            try:
-                field = self.header[column]
-            except IndexError:
-                field = None
-            default = self.default_row.get(field)
-            default_row.append(default)
+        default_row = self._default_row()
         for row in range(first, last + 1):
             self._main_data[row] = default_row.copy()
         top_left = self.index(first, 0)

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -16,6 +16,7 @@ from itertools import chain
 from PySide6.QtCore import QAbstractItemModel, QAbstractTableModel, QModelIndex, QPersistentModelIndex, Qt, Slot
 from PySide6.QtGui import QColor
 from spinedb_api import DatabaseMapping
+from spinedb_api.helpers import group_consecutive
 from spinedb_api.temp_id import TempId
 from ...helpers import preferred_row_height
 from ...mvcmodels.shared import ITEM_ROLE
@@ -187,8 +188,10 @@ class StackedViewMixin:
         else:
             db_map = self.db_maps[0]
         database_name = self.db_mngr.name_registry.display_name(db_map.sa_url)
+        rows_to_update = model.defaulted_rows()
         model.set_default_row(database=database_name, **default_data.default_data)
-        model.set_rows_to_default(model.rowCount() - 1)
+        for first, last in group_consecutive(rows_to_update):
+            model.set_rows_to_default(first, last)
         model.db_map = db_map
 
     def clear_all_filters(self):

--- a/tests/mvcmodels/test_empty_row_model.py
+++ b/tests/mvcmodels/test_empty_row_model.py
@@ -1,0 +1,45 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from PySide6.QtCore import QModelIndex
+from spinetoolbox.mvcmodels.empty_row_model import EmptyRowModel
+from tests.mock_helpers import assert_table_model_data_pytest
+
+
+def test_default_row(parent_object):
+    model = EmptyRowModel(parent_object, ["head_1", "head_2"])
+    model.set_default_row(head_1=1.1, head_2=2.2)
+    assert model.insertRow(0, QModelIndex())
+    expected = [[1.1, 2.2]]
+    assert_table_model_data_pytest(model, expected)
+    assert model.defaulted_rows() == [0]
+
+
+def test_default_row_without_header(parent_object):
+    model = EmptyRowModel(parent_object)
+    assert model.insertRow(0, QModelIndex())
+    assert model.insertColumns(0, 2, QModelIndex())
+    model.set_default_row(head_1=1.1, head_2=2.2)
+    model.set_rows_to_default(0)
+    expected = [[None, None, None]]
+    assert_table_model_data_pytest(model, expected)
+    assert model.defaulted_rows() == [0]
+
+
+def test_defaulted_rows(parent_object):
+    model = EmptyRowModel(parent_object, ["head_1", "head_2"])
+    model.set_default_row(head_1=1.1)
+    assert model.insertRows(0, 3, QModelIndex())
+    assert model.defaulted_rows() == [0, 1, 2]
+    assert model.setData(model.index(1, 1), 2.2)
+    assert model.defaulted_rows() == [0, 2]
+    assert model.setData(model.index(2, 0), None)
+    assert model.defaulted_rows() == [0, 3]


### PR DESCRIPTION
This fixes a bug where existing data in the empty rows would be cleared when user selected e.g. `Type new alternative name here...` option in Alternative list.

Re #3326


## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
